### PR TITLE
Modify docker build to use GOPROXY if set

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,18 +1,36 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
-ENV OPERATOR_PATH=/go/src/github.com/openshift/rbac-permissions-operator
-COPY . ${OPERATOR_PATH}
-WORKDIR ${OPERATOR_PATH}
-ENV GO111MODULE=on
-RUN \
-  cd ${OPERATOR_PATH} && \
-  go mod download && \
-  make gobuild
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+# Allow specifying a GOPROXY cache during build to speed up dependency resolution
+ARG GOPROXY=https://proxy.golang.org
+
 ENV OPERATOR_PATH=/go/src/github.com/openshift/rbac-permissions-operator \
-    OPERATOR_BIN=rbac-permissions-operator
+    GO111MODULE=on \
+    GOPROXY=$GOPROXY
 
-WORKDIR /root/
+RUN mkdir -p ${OPERATOR_PATH}
+WORKDIR ${OPERATOR_PATH}
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN make gobuild
+
+####
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+
+ENV OPERATOR_PATH=/go/src/github.com/openshift/rbac-permissions-operator \
+    OPERATOR_BIN=rbac-permissions-operator \
+    USER_UID=1001 \
+    USER_NAME=rbac-permissions-operator
+
+# install operator binary
 COPY --from=builder ${OPERATOR_PATH}/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}
+
 LABEL io.openshift.managed.name="rbac-permissions-operator" \
       io.openshift.managed.description="Operator to manage permissions."

--- a/standard.mk
+++ b/standard.mk
@@ -17,22 +17,22 @@ endif
 
 # Generate version and tag information from inputs
 COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$$"`..HEAD --count)
-CURRENT_COMMIT=$(shell git rev-parse --short=8 HEAD)
+CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
 OPERATOR_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(CURRENT_COMMIT)
 
-IMG?=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):v$(OPERATOR_VERSION)
-OPERATOR_IMAGE_URI=${IMG}
+OPERATOR_IMAGE_URI=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):v$(OPERATOR_VERSION)
 OPERATOR_IMAGE_URI_LATEST=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):latest
 OPERATOR_DOCKERFILE ?=build/Dockerfile
 
 BINFILE=build/_output/bin/$(OPERATOR_NAME)
 MAINPACKAGE=./cmd/manager
+export GO111MODULE=on
+export GOPROXY?=https://proxy.golang.org
 GOENV=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 GOFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
 
-TESTTARGETS := $(shell go list -e ./... | egrep -v "/(vendor)/")
 # ex, -v
-TESTOPTS := 
+TESTOPTS :=
 
 ALLOW_DIRTY_CHECKOUT?=false
 
@@ -42,13 +42,13 @@ default: gobuild
 clean:
 	rm -rf ./build/_output
 
-.PHONY: isclean 
+.PHONY: isclean
 isclean:
-	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." && exit 1)
+	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." >&2 && exit 1)
 
 .PHONY: build
 build: isclean envtest
-	docker build . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
+	docker build --build-arg "GOPROXY=${GOPROXY}" . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
 	docker tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
 
 .PHONY: push
@@ -67,12 +67,12 @@ gobuild: gocheck gotest ## Build binary
 
 .PHONY: gotest
 gotest:
-	go test $(TESTOPTS) $(TESTTARGETS)
+	go test $(TESTOPTS) $(shell GO111MODULE=$(GO111MODULE) GOPROXY=$(GOPROXY) go list -mod=readonly -e ./... | egrep -v "/(vendor)/")
 
 .PHONY: envtest
 envtest:
 	@# test that the env target can be evaluated, required by osd-operators-registry
-	@eval $$($(MAKE) env --no-print-directory) || (echo 'Unable to evaulate output of `make env`.  This breaks osd-operators-registry.' && exit 1)
+	@eval $$($(MAKE) env --no-print-directory) || (echo 'Unable to evaulate output of `make env`.  This breaks osd-operators-registry.' >&2 && exit 1)
 
 .PHONY: test
 test: envtest gotest


### PR DESCRIPTION
This PR copies the Dockerfile and standard.mk changes from the managed-velero-operator to bring in the following changes:
- Use GOPROXY if set
- Cache go modules in a layer during build to improve build times
- Use go1.12 and UBI for base images