### PR TITLE
Add conditions functionality to SubjectPermission object

### DIFF
--- a/deploy/crds/managed_v1alpha1_subjectpermission_crd.yaml
+++ b/deploy/crds/managed_v1alpha1_subjectpermission_crd.yaml
@@ -75,6 +75,11 @@ spec:
               description: List of conditions for the CR
               items:
                 properties:
+                  clusterRoleName:
+                    description: ClusterRoleName in which this condition is true
+                    items:
+                      type: string
+                    type: array
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition
                       was active for the CR
@@ -94,7 +99,6 @@ spec:
                     description: Type is the type of the condition
                     type: string
                 required:
-                - type
                 - lastTransitionTime
                 - status
                 - state

--- a/pkg/apis/managed/v1alpha1/subjectpermission_types.go
+++ b/pkg/apis/managed/v1alpha1/subjectpermission_types.go
@@ -69,10 +69,10 @@ type SubjectPermissionState string
 type SubjectPermissionType string
 
 const (
-	// SubjectPermissionCreated const for Created status
-	SubjectPermissionCreated SubjectPermissionType = "Created"
-	// SubjectPermissionFailed const for Failed status
-	SubjectPermissionFailed SubjectPermissionType = "Failed"
+	// ClusterRoleBindingCreated const for ClusterRoleBindingCreated status
+	ClusterRoleBindingCreated SubjectPermissionType = "ClusterRoleBindingCreated"
+	// RoleBindingCreated const for RoleBindingCreated status
+	RoleBindingCreated SubjectPermissionType = "RoleBindingCreated"
 	// SubjectPermissionStateCreated const for Created state
 	SubjectPermissionStateCreated SubjectPermissionState = "Created"
 	// SubjectPermissionStateFailed const for Failed state

--- a/pkg/controller/utils/controllerutil.go
+++ b/pkg/controller/utils/controllerutil.go
@@ -123,11 +123,24 @@ func UpdateCondition(conditions []managedv1alpha1.Condition, message string, clu
 
 	existingCondition := FindRbacCondition(conditions, conditionType)
 
+	// create a map of all unique elements in clusterRoleNames slice
+	encountered := map[string]bool{}
+	for v := range clusterRoleNames {
+		encountered[clusterRoleNames[v]] = true
+	}
+
+	// place all keys from map into result slice
+	// this prevents the duplication of clusterRoleNames
+	result := []string{}
+	for key := range encountered {
+		result = append(result, key)
+	}
+
 	if existingCondition == nil {
 		conditions = append(
 			conditions, managedv1alpha1.Condition{
 				LastTransitionTime: now,
-				ClusterRoleNames:   clusterRoleNames,
+				ClusterRoleNames:   result,
 				Message:            message,
 				Status:             status,
 				State:              state,
@@ -139,7 +152,7 @@ func UpdateCondition(conditions []managedv1alpha1.Condition, message string, clu
 			existingCondition.LastTransitionTime = now
 		}
 		existingCondition.Message = message
-		existingCondition.ClusterRoleNames = clusterRoleNames
+		existingCondition.ClusterRoleNames = result
 		existingCondition.Status = status
 		existingCondition.State = state
 	}


### PR DESCRIPTION
Currently no conditions are being updated when ClusterRoleBindings and RoleBindings are being created. This PR adds the functionality to add/update conditions in the event of ClusterRoleBinding and/or RoleBinding creation.