### PR TITLE
Add check for clusterRoleNames

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -25,7 +25,12 @@ rules:
   - rolebindings
   - roles
   verbs:
-  - '*'
+  - create
+  - get
+  - list 
+  - watch
+  - update
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -36,6 +41,6 @@ rules:
 - apiGroups:
   - managed.openshift.io
   resources:
-  - subjectpermissions
+  - '*'
   verbs:
   - '*'

--- a/deploy/crds/managed_v1alpha1_subjectpermission_cr.yaml
+++ b/deploy/crds/managed_v1alpha1_subjectpermission_cr.yaml
@@ -4,9 +4,6 @@ metadata:
   name: example-subjectpermission
 spec:
   subjectKind: Group
-  subjectName: Test
-  permissions:
-    -
-      clusterRoleName: bar
-      namespacesAllowedRegex: openshift.*
-      allowFirst: true
+  subjectName: dedicatedadmin
+  clusterPermissions :
+    - bar

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -151,7 +151,7 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 		subjectPermission.Status.Conditions = controllerutil.UpdateCondition(subjectPermission.Status.Conditions, "Successfully created all roleBindings", successfulClusterRoleNames, true, managedv1alpha1.SubjectPermissionStateCreated, managedv1alpha1.RoleBindingCreated)
 		err = r.client.Status().Update(context.TODO(), &subjectPermission)
 		if err != nil {
-			reqLogger.Error(err, "Failed to update condition in subjectpermission controller when successfully created all cluster role bindings")
+			reqLogger.Error(err, "Failed to update condition in namespace controller when successfully created all cluster role bindings")
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{}, nil

--- a/pkg/controller/utils/controllerutil.go
+++ b/pkg/controller/utils/controllerutil.go
@@ -22,12 +22,16 @@ func PopulateCrPermissionClusterRoleNames(subjectPermission *managedv1alpha1.Sub
 	permissions := subjectPermission.Spec.Permissions
 
 	var permissionClusterRoleNames []string
+	var found bool
 
-	for _, i := range clusterRoleList.Items {
-		for _, a := range permissions {
-			if i.Name != a.ClusterRoleName {
-				permissionClusterRoleNames = append(permissionClusterRoleNames, a.ClusterRoleName)
+	for _, i := range permissions {
+		for _, a := range clusterRoleList.Items {
+			if i.ClusterRoleName == a.Name {
+				found = true
 			}
+		}
+		if !found {
+			permissionClusterRoleNames = append(permissionClusterRoleNames, i.ClusterRoleName)
 		}
 	}
 


### PR DESCRIPTION
currently operator is broken when the clusterRoleName we pass in the CR does not exist on the cluster. The solution is "all-or-nothing". If any clusterRoleNames do not exist on the cluster, operator will update status and exit.