### PR TITLE
Bind rbac ServiceAccount to cluster-admin

### DIFF
--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -8,5 +8,5 @@ subjects:
   namespace: openshift-rbac-permissions
 roleRef:
   kind: ClusterRole
-  name: rbac-permissions-operator
+  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
In order for the rbac operator to have correct permissions to assign to subjects, it's SA needs to be bound to the clusterrole `cluster-admin` 