### PR TITLE
Remove operator-sdk generate from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ default: gobuild
 
 # Build the docker image
 .PHONY: docker-build
-docker-build: operator-sdk-generate
+docker-build:
 	$(MAKE) build
 
 # Push the docker image


### PR DESCRIPTION
This PR removes operator-sdk generate from the Makefile since APP-SRE build pipeline doesn't have operator-sdk CLI installed. 