### PR TITLE
Register prometheus operator scheme for ServiceMonitor creation

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/rbac-permissions-operator/pkg/apis"
 	"github.com/openshift/rbac-permissions-operator/pkg/controller"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -108,6 +109,11 @@ func main() {
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	if err := monitoringv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "error registering prometheus monitoring objects")
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	contrib.go.opencensus.io/exporter/ocagent v0.4.9 // indirect
 	github.com/Azure/go-autorest v11.5.2+incompatible // indirect
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 // indirect
+	github.com/coreos/prometheus-operator v0.31.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/emicklei/go-restful v2.8.1+incompatible // indirect
 	github.com/go-openapi/spec v0.18.0


### PR DESCRIPTION
Currently, the localmetrics service monitor is not being created when the operator starts. 

```
{"level":"info","ts":1575308345.2894447,"logger":"userMetrics","msg":"Error creating Service Monitor","Error":"no kind is registered for the type v1.ServiceMonitor in scheme \"pkg/runtime/scheme.go:101\""}
{"level":"error","ts":1575308345.28946,"logger":"cmd","msg":"Failed to configure OSD metrics","error":"no kind is registered for the type v1.ServiceMonitor in scheme \"pkg/runtime/scheme.go:101\"","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nmain.main\n\tsrc/github.com/openshift/rbac-permissions-operator/cmd/manager/main.go:135\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:200"}
{"level":"info","ts":1575308345.289505,"logger":"cmd","msg":"Starting the Cmd."}
```
To fix this, the prometheus operator scheme needs to be registered with the k8s client.