### PR TITLE
Fix rolebindings creation on customer namespaces

### DIFF
--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -129,9 +129,9 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 			if namespaceInSlice(instance.Name, safeList) {
 
 				roleBinding := controllerutil.NewRoleBindingForClusterRole(permission.ClusterRoleName, subjectPermission.Spec.SubjectName, subjectPermission.Spec.SubjectKind, instance.Name)
-				// if rolebinding is already created in the namespace, there's nothing to do
+				// if rolebinding is already created in the namespace, continue to next iteration
 				if rolebindingInNamespace(roleBinding, roleBindingList) {
-					return reconcile.Result{}, nil
+					continue
 				}
 
 				err := r.client.Create(context.TODO(), roleBinding)
@@ -148,7 +148,6 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 				roleBindingName := fmt.Sprintf("%s-%s", permission.ClusterRoleName, subjectPermission.Spec.SubjectName)
 				reqLogger.Info(fmt.Sprintf("RoleBinding %s created successfully in namespace %s", roleBindingName, instance.Name))
 			}
-			return reconcile.Result{}, nil
 		}
 		subjectPermission.Status.Conditions = controllerutil.UpdateCondition(subjectPermission.Status.Conditions, "Successfully created all roleBindings", successfulClusterRoleNames, true, managedv1alpha1.SubjectPermissionStateCreated, managedv1alpha1.RoleBindingCreated)
 		err = r.client.Status().Update(context.TODO(), &subjectPermission)
@@ -156,7 +155,6 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 			reqLogger.Error(err, "Failed to update condition in namespace controller when successfully created all cluster role bindings")
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{}, nil
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
Bug discovered that the operator is granting permisisons to dedicated-admin SA only and not to the dedicated-admins group (or vice versa). This bug is tracked on OSD-2572

How these changes fix this issue:
line #134 - `continue` instead of `return reconcile.Result{}, nil` because we do not want to exit reconcile 
    loop if rolebinding already exists, should just move on to next iteration
line #151 - reconcile loop exits while we are still in the inner for loop, this prevents other rolebindings 
    from being created
line #159 - reconcile loop exits after one permission, this prevents other permissions from being loop 
    through, thus prevents rolebindings from being created.


sample logs where line 151 is getting hit and reconcile exits when it should not be
`{"level":"info","ts":1576855464.0256724,"logger":"controller_namespace","msg":"RoleBinding dedicated-admins-project-system:serviceaccounts:dedicated-admin created successfully in namespace test-ns","Request.Namespace":"","Request.Name":"test-ns"}
{"level":"info","ts":1576855464.0256944,"logger":"controller_namespace","msg":"should not exit here! -- line 152 !@#$%!@#$!@#$!@#$","Request.Namespace":"","Request.Name":"test-ns"}
{"level":"info","ts":1576855464.0257144,"logger":"controller_namespace","msg":"Reconciling Namespace","Request.Namespace":"","Request.Name":"test-ns"}
{"level":"info","ts":1576855464.0404968,"logger":"controller_namespace","msg":"RoleBinding dedicated-admins-project-dedicated-admins created successfully in namespace test-ns","Request.Namespace":"","Request.Name":"test-ns"}
{"level":"info","ts":1576855464.0405273,"logger":"controller_namespace","msg":"should not exit here! -- line 152 !@#$%!@#$!@#$!@#$","Request.Namespace":"","Request.Name":"test-ns"}`

After the changes, we get sample logs:
`{"level":"info","ts":1576865570.0363777,"logger":"controller_namespace","msg":"Reconciling Namespace","Request.Namespace":"","Request.Name":"new-ns"}
{"level":"info","ts":1576865570.0741634,"logger":"controller_namespace","msg":"RoleBinding dedicated-admins-project-system:serviceaccounts:dedicated-admin created successfully in namespace new-ns","Request.Namespace":"","Request.Name":"new-ns"}
{"level":"info","ts":1576865570.0853205,"logger":"controller_namespace","msg":"RoleBinding admin-system:serviceaccounts:dedicated-admin created successfully in namespace new-ns","Request.Namespace":"","Request.Name":"new-ns"}
{"level":"info","ts":1576865570.0894377,"logger":"controller_namespace","msg":"!@#$!@#$ keep going !@#$!@#$","Request.Namespace":"","Request.Name":"new-ns"}
{"level":"info","ts":1576865570.1037798,"logger":"controller_namespace","msg":"RoleBinding dedicated-admins-project-dedicated-admins created successfully in namespace new-ns","Request.Namespace":"","Request.Name":"new-ns"}
{"level":"info","ts":1576865570.109332,"logger":"controller_namespace","msg":"RoleBinding admin-dedicated-admins created successfully in namespace new-ns","Request.Namespace":"","Request.Name":"new-ns"}
{"level":"info","ts":1576865570.1180785,"logger":"controller_namespace","msg":"!@#$!@#$ keep going !@#$!@#$","Request.Namespace":"","Request.Name":"new-ns"}`

with the expected rolebindings:
`oc get rolebindings -n new-ns
NAME                                                              AGE
admin-dedicated-admins                                            49s
admin-system:serviceaccounts:dedicated-admin                      49s
dedicated-admins-project-dedicated-admins                         49s
dedicated-admins-project-system:serviceaccounts:dedicated-admin   49s`

Steps to reproduce:
1. start crc
2. deploy the operator manually
3. add a log message to line 134, 151, and 159 to see if we exit there or not
4. comment out the return statements
5. apply the SubjectPermission CRs to ensure proper rolebindings have been created
