### PR TITLE
Move cluster-monitoring label inside metadata

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -32,8 +32,8 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-rbac-permissions
-      labels:
-        openshift.io/cluster-monitoring: 'true'
+        labels:
+          openshift.io/cluster-monitoring: 'true'
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:


### PR DESCRIPTION
Currently the cluster-monitoring label is in the wrong place. This PR fixes that issue.