### PR TITLE
Fix change that snuck into go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/openshift/rbac-permissions-operator
 
-go 1.14
-
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.4.9 // indirect
 	github.com/Azure/go-autorest v11.5.2+incompatible // indirect


### PR DESCRIPTION
I must have run a local build which changed go.mod in https://github.com/openshift/rbac-permissions-operator/pull/65.  This PR removes that change.