### PR TITLE
Pin operator to run on infra nodes

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,16 +15,18 @@ spec:
       serviceAccountName: rbac-permissions-operator
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/infra
-                operator: Exists
-            weight: 1
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "node-role.kubernetes.io"
+                operator: In
+                values: 
+                  - infra
       tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/infra
-          operator: Exists
+      - operator: Equal
+        key: node-role.kubernetes.io
+        value: infra
+        effect: PreferNoSchedule
       containers:
         - name: rbac-permissions-operator
           # Replace this with the built image name

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -74,16 +74,18 @@ objects:
         image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
         affinity:
           nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-              weight: 1
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: "node-role.kubernetes.io"
+                  operator: In
+                  values: 
+                    - infra
         tolerations:
-          - effect: NoSchedule
-            key: node-role.kubernetes.io/infra
-            operator: Exists
+        - operator: Equal
+          key: node-role.kubernetes.io
+          value: infra
+          effect: PreferNoSchedule
         displayName: RBAC Permissions Operator
         icon:
           base64data: ''


### PR DESCRIPTION
Per OHSS-2971

Change from `preferredDuringSchedulingIgnoredDuringExecution` to `requiredDuringSchedulingIgnoredDuringExecution` as it sets a hard requirement for the operator to run on infra node. Check out description of https://github.com/openshift/cloud-ingress-operator/pull/75 for more details.