### PR TITLE
Use go 1.13 in go.mod (to match docker build)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/rbac-permissions-operator
 
-go 1.14
+go 1.13
 
 require (
 	github.com/coreos/prometheus-operator v0.35.1


### PR DESCRIPTION
The Dockerfile (even before boilerplate) and prow configuration were both using go 1.13 for builds. For reasons unknown, go.mod claimed 1.14. Things build the same when that line is synced with the rest; so do that.

Forensics: This was switched from 1.13 to 1.14 via commit fbb7d61 as part of operator-sdk upgrade in PR #71. Suspiciously, that's the commit that went from osdk 0.13 to 0.14. Overenthusiastic search/replace? (FWIW, none of the other osdk upgrades I've seen/done have had/needed this switch.)