### PR TITLE
Add report status from OSD operators to OCM

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -11,12 +11,19 @@ parameters:
 - name: REPO_NAME
   value: rbac-permissions-operator
   required: true
+- name: OPERATOR_NAME
+  value: rbac-permissions-operator
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
+    annotations:
+      component-display-name: RBAC Permissions Operator
+      component-name: ${OPERATOR_NAME}
+      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${OPERATOR_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
     labels:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -11,8 +11,8 @@ parameters:
 - name: REPO_NAME
   value: rbac-permissions-operator
   required: true
-- name: OPERATOR_NAME
-  value: rbac-permissions-operator
+- name: DISPLAY_NAME
+  value: RBAC Permissions Operator
   required: true
 metadata:
   name: selectorsyncset-template
@@ -21,9 +21,9 @@ objects:
   kind: SelectorSyncSet
   metadata:
     annotations:
-      component-display-name: RBAC Permissions Operator
-      component-name: ${OPERATOR_NAME}
-      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${OPERATOR_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
+      component-display-name: ${DISPLAY_NAME}
+      component-name: ${REPO_NAME}
+      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${REPO_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
     labels:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/SDE-591

parsing the template using `oc process --local` looks like this:

```yaml
"telemeter-query": "csv_succeeded{_id=\"$CLUSTER_ID\",name=~\"rbac-permissions-operator.*\",exported_namespace=~\"openshift-.*\",namespace=\"openshift-operator-lifecycle-manager\"} == 1"
```

The `CLUSTER_ID` parameter is not going to be replaced via this template, but from OCM.