### PR TITLE
Made the state field optional in status

### DIFF
--- a/deploy/crds/managed.openshift.io_subjectpermissions_crd.yaml
+++ b/deploy/crds/managed.openshift.io_subjectpermissions_crd.yaml
@@ -102,8 +102,6 @@ spec:
             state:
               description: State that this condition represents
               type: string
-          required:
-            - state
           type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/managed/v1alpha1/subjectpermission_types.go
+++ b/pkg/apis/managed/v1alpha1/subjectpermission_types.go
@@ -42,7 +42,7 @@ type SubjectPermissionStatus struct {
 	// List of conditions for the CR
 	Conditions []Condition `json:"conditions,omitempty"`
 	// State that this condition represents
-	State string `json:"state"`
+	State string `json:"state,omitempty"`
 }
 
 // Condition defines a single condition of running the operator against an instance of the SubjectPermission CR

--- a/pkg/apis/managed/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/managed/v1alpha1/zz_generated.openapi.go
@@ -148,7 +148,6 @@ func schema_pkg_apis_managed_v1alpha1_SubjectPermissionStatus(ref common.Referen
 						},
 					},
 				},
-				Required: []string{"state"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
The `State` field in the status is not really used in the controller and is never set. Due to how the API validation is done in Kubernetes an empty string is set to null and this is not allowed according to the CRD. This causes some CSV upgrades to fail in newer versions of openshift.