### PR TITLE
Add new targets to Makefile to test locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,18 @@ include boilerplate/generated-includes.mk
 .PHONY: boilerplate-update
 boilerplate-update:
 	@boilerplate/update
+
+.PHONY: predeploy-rbac-permissions-operator
+predeploy-rbac-permissions-operator: ## Predeploy AWS Account Operator
+	# Create rbac-permissions-operator namespace
+	@oc get namespace rbac-permissions-operator && oc project rbac-permissions-operator || oc create namespace rbac-permissions-operator
+	# Create rbac-permissions-operator CRDs
+	@oc apply -f deploy/crds/managed.openshift.io_subjectpermissions_crd.yaml
+
+.PHONY: predeploy
+predeploy: predeploy-rbac-permissions-operator
+
+.PHONY: deploy-local
+deploy-local: ## Deploy Operator locally
+	@FORCE_DEV_MODE=local operator-sdk run --local --namespace=rbac-permissions-operator
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # RBAC Permissions Operator
 
 ## Summary
-The RBAC-Permissions-Operator was created for the Openshift Dedicated platform to manage various permissions (via k8s RBAC policies) to 
-all the projects/namespaces within an OpenShift Dedicated cluster. The permissions must allow for cluster and namespace scope access 
+The RBAC-Permissions-Operator was created for the Openshift Dedicated platform to manage various permissions (via k8s RBAC policies) to
+all the projects/namespaces within an OpenShift Dedicated cluster. The permissions must allow for cluster and namespace scope access
 and the ability to safe list and/or blocklist namespaces.
 
 It contains the following components:
@@ -19,10 +19,8 @@ the RoleBinding assignment.
 To test a new version of the operator locally using CRC you need to:
 
 1. start CRC
-1. run `oc create namespace rbac-permissions-operator`
-1. run `oc project rbac-permissions-operator`
-1. run `oc apply -f deploy/crds/managed_v1alpha1_subjectpermission_crd.yaml`
-1. run `operator-sdk up local`
+1. run `make predeploy`
+1. on a separate terminal run `make deploy-local`
 1. apply any valid CR and watch for log changes
 
 # Controllers
@@ -34,15 +32,15 @@ create `RoleBindings` in that namespace to the corresponding subject.
 
 ## SubjectPermission Controller
 
-The subjectpermission-controller is triggered by a new SubjectPermission CR or a change to an existing SubjectPermission CR. It is 
-responsible for the creation of `ClusterRoleBinding` and `Rolebinding`. It looks at the `subjectName` and the `clusterRoleName` passed 
+The subjectpermission-controller is triggered by a new SubjectPermission CR or a change to an existing SubjectPermission CR. It is
+responsible for the creation of `ClusterRoleBinding` and `Rolebinding`. It looks at the `subjectName` and the `clusterRoleName` passed
 in by the SubjectPermission CR. If corresponding `ClusterRoleBinding` and/or `RoleBinding` do not exist then create them.
 
 # Custom Resources
 
 ## SubjectPermission CR
 
-The SubjectPermission CR holds the `SubjectKind`, `SubjectName`, `clusterPermissions`, and `permissions` needed to configure the rbac policies needed for any given subject. All configurations can be found at [managed-cluster-config](https://github.com/openshift/managed-cluster-config/tree/master/deploy/rbac-permissions-operator-config "rbac-permissions-operator-config") 
+The SubjectPermission CR holds the `SubjectKind`, `SubjectName`, `clusterPermissions`, and `permissions` needed to configure the rbac policies needed for any given subject. All configurations can be found at [managed-cluster-config](https://github.com/openshift/managed-cluster-config/tree/master/deploy/rbac-permissions-operator-config "rbac-permissions-operator-config")
 
 ```yaml
 apiVersion: managed.openshift.io/v1alpha1
@@ -56,14 +54,14 @@ spec:
   clusterPermissions:
     - dedicated-admins-cluster
   permissions:
-    - 
+    -
       clusterRoleName: dedicated-admins-project
       namespacesAllowedRegex: ".*"
       namespacesDeniedRegex: "(^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)"
       allowFirst: true
-    - 
-      clusterRoleName: admin 
-      namespacesAllowedRegex: ".*" 
-      namespacesDeniedRegex: "(^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)" 
+    -
+      clusterRoleName: admin
+      namespacesAllowedRegex: ".*"
+      namespacesDeniedRegex: "(^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)"
       allowFirst: true
 ```


### PR DESCRIPTION
To improve the local development process, I have added new targets to the Makefile in order to prepare (`predeploy`) the operator for deployment and also run the operator locally(`deploy-local`).

PTAL