### PR TITLE
[OSD-7119] remove unused status field state

### DIFF
--- a/deploy/crds/managed.openshift.io_subjectpermissions_crd.yaml
+++ b/deploy/crds/managed.openshift.io_subjectpermissions_crd.yaml
@@ -99,9 +99,6 @@ spec:
                   - status
                 type: object
               type: array
-            state:
-              description: State that this condition represents
-              type: string
           type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/managed/v1alpha1/subjectpermission_types.go
+++ b/pkg/apis/managed/v1alpha1/subjectpermission_types.go
@@ -41,8 +41,6 @@ type Permission struct {
 type SubjectPermissionStatus struct {
 	// List of conditions for the CR
 	Conditions []Condition `json:"conditions,omitempty"`
-	// State that this condition represents
-	State string `json:"state,omitempty"`
 }
 
 // Condition defines a single condition of running the operator against an instance of the SubjectPermission CR

--- a/pkg/apis/managed/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/managed/v1alpha1/zz_generated.openapi.go
@@ -140,13 +140,6 @@ func schema_pkg_apis_managed_v1alpha1_SubjectPermissionStatus(ref common.Referen
 							},
 						},
 					},
-					"state": {
-						SchemaProps: spec.SchemaProps{
-							Description: "State that this condition represents",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 				},
 			},
 		},


### PR DESCRIPTION
Currently the rbac-permissions-operator's SubjectPermission custom resource contains a status subresource field `state` that is unused. This PR removes this field.


PTAL.  cc: @jharrington22 
