### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,15 @@
 reviewers:
-- sam-nguyen7
-- fahlmant
-- clcollins
-- iamkirkbater
-- rogbas
+- bmeng
+- mrbarge
+- ravitri
+- anjoshi24
+- a7vicky
+- T0MASD
+
 approvers:
-- fahlmant
+- mrbarge
+- bmeng
+- ravitri
+
 maintainers:
+- mrbarge


### PR DESCRIPTION
Per the recent assignment of functional team ownership / SDE-1417, `OWNERS` is proposed to be updated to a new set of reviewers and approvers.

cc @fahlmant - I'm happy to keep you and others in the list if you'd still prefer to be there.