### PR TITLE
[OSD-10502] update the base image to ubi-micro

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-micro:latest
 
 ENV USER_UID=1001 \
     USER_NAME=rbac-permissions-operator


### PR DESCRIPTION
Update the build base image to ubi-micro to reduce the future security maintenance overhead
