### PR TITLE
Ignoring container runtime mock client for codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,3 +24,6 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
+
+ignore:
+  - pkg/util/test/generated/mocks/client/cr-client.go


### PR DESCRIPTION
### What type of PR is this?
_(test)_

### What this PR does / why we need it?
The code coverage shown for now includes mock clients which don't need to be tested as such. So this PR adds the ignore directive for codecov configuration to exclude the coverage for generated mock files.
