### PR TITLE
[OSD-2358] Removing allowFirst field

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,8 @@ spec:
       clusterRoleName: dedicated-admins-project
       namespacesAllowedRegex: ".*"
       namespacesDeniedRegex: "(^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)"
-      allowFirst: true
     -
       clusterRoleName: admin
       namespacesAllowedRegex: ".*"
       namespacesDeniedRegex: "(^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)"
-      allowFirst: true
 ```

--- a/api/v1alpha1/subjectpermission_types.go
+++ b/api/v1alpha1/subjectpermission_types.go
@@ -46,9 +46,6 @@ type Permission struct {
 	NamespacesAllowedRegex string `json:"namespacesAllowedRegex,omitempty"`
 	// NamespacesDeniedRegex representing denied Namespaces
 	NamespacesDeniedRegex string `json:"namespacesDeniedRegex,omitempty"`
-	// Flag to indicate if "allow" regex is applied first
-	// If 'true' order is Allow then Deny, Else order is Deny then Allow
-	AllowFirst bool `json:"allowFirst"`
 }
 
 // +k8s:openapi-gen=true

--- a/deploy/crds/managed.openshift.io_subjectpermissions.yaml
+++ b/deploy/crds/managed.openshift.io_subjectpermissions.yaml
@@ -48,11 +48,6 @@ spec:
                   description: Permission defines a Role that is bound to the Subject
                     Allowed in specific Namespaces
                   properties:
-                    allowFirst:
-                      description: Flag to indicate if "allow" regex is applied first
-                        If 'true' order is Allow then Deny, Else order is Deny then
-                        Allow
-                      type: boolean
                     clusterRoleName:
                       description: ClusterRoleName to bind to the Subject as a RoleBindings
                         in allowed Namespaces
@@ -64,7 +59,6 @@ spec:
                       description: NamespacesDeniedRegex representing denied Namespaces
                       type: string
                   required:
-                  - allowFirst
                   - clusterRoleName
                   type: object
                 type: array

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -101,7 +101,6 @@ func addRBACNamespacePermissionMetric(gp *managedv1alpha1.SubjectPermission) {
 			"cluster_role_name":       permission.ClusterRoleName,
 			"namespace_allow":         permission.NamespacesAllowedRegex,
 			"namespace_deny":          permission.NamespacesDeniedRegex,
-			"allow_first":             allowFirstToString(permission.AllowFirst),
 			"state":                   "1",
 		}).Set(1.0)
 	}
@@ -119,7 +118,6 @@ func deleteRBACNamespacePermissionMetric(gp *managedv1alpha1.SubjectPermission) 
 			permission.ClusterRoleName,
 			permission.NamespacesAllowedRegex,
 			permission.NamespacesDeniedRegex,
-			allowFirstToString(permission.AllowFirst),
 			"1",
 		)
 		// It's possible that we weren't able to delete the metric, so let's log a message to that effect.

--- a/pkg/utility/subjectpermissions_test.go
+++ b/pkg/utility/subjectpermissions_test.go
@@ -30,7 +30,6 @@ func TestGetClusterRoleBindingsForSubjectPermissions(t *testing.T) {
 					{
 						ClusterRoleName:        "sre-admins-project",
 						NamespacesAllowedRegex: "^(default|openshift.*|kube.*)$",
-						AllowFirst:             true,
 					},
 				},
 			},


### PR DESCRIPTION
### What type of PR is this?
_(refactor)_


### What this PR does / why we need it?
Based on [OSD-2358](https://issues.redhat.com/browse/OSD-2358), this PR removes the allowFirst field from subjectPermission types and CRD because the AllowFirst field is no longer needed/being used

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-2358](https://issues.redhat.com/browse/OSD-2358)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
