### PR TITLE
Add support for subjectNamespace

### DIFF
--- a/api/v1alpha1/subjectpermission_types.go
+++ b/api/v1alpha1/subjectpermission_types.go
@@ -29,6 +29,9 @@ type SubjectPermissionSpec struct {
 	SubjectKind string `json:"subjectKind"`
 	// Name of the Subject granted permissions by the operator
 	SubjectName string `json:"subjectName"`
+	// Namespace of the Subject granted permissions by the operator
+	// +optional
+	SubjectNamespace string `json:"subjectNamespace"`
 	// List of permissions applied at Cluster scope
 	// +optional
 	ClusterPermissions []string `json:"clusterPermissions,omitempty"`

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -42,6 +42,14 @@ func schema_openshift_rbac_permissions_operator_api_v1alpha1_SubjectPermissionSp
 							Format:      "",
 						},
 					},
+					"subjectNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace of the Subject granted permissions by the operator",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"clusterPermissions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "List of permissions applied at Cluster scope",

--- a/controllers/namespace/namespace_controller.go
+++ b/controllers/namespace/namespace_controller.go
@@ -106,7 +106,7 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 			// if namespace is in safeList, create RoleBinding
 			if NamespaceInSlice(instance.Name, safeList) && controllerutil.ValidateNamespace(instance) {
 
-				roleBinding := controllerutil.NewRoleBindingForClusterRole(permission.ClusterRoleName, subPerm.Spec.SubjectName, subPerm.Spec.SubjectKind, instance.Name)
+				roleBinding := controllerutil.NewRoleBindingForClusterRole(permission.ClusterRoleName, subPerm.Spec.SubjectName, subPerm.Spec.SubjectNamespace, subPerm.Spec.SubjectKind, instance.Name)
 				// if rolebinding is already created in the namespace, continue to next iteration
 				if RolebindingInNamespace(roleBinding, roleBindingList) {
 					continue

--- a/controllers/subjectpermission/subjectpermission_controller.go
+++ b/controllers/subjectpermission/subjectpermission_controller.go
@@ -196,7 +196,7 @@ func (r *SubjectPermissionReconciler) Reconcile(ctx context.Context, request ctr
 				_ = r.Client.List(context.TODO(), rbList, opts...)
 
 				// create roleBinding
-				roleBinding := controllerutil.NewRoleBindingForClusterRole(permission.ClusterRoleName, instance.Spec.SubjectName, instance.Spec.SubjectKind, ns)
+				roleBinding := controllerutil.NewRoleBindingForClusterRole(permission.ClusterRoleName, instance.Spec.SubjectName, instance.Spec.SubjectNamespace, instance.Spec.SubjectKind, ns)
 
 				err := r.Client.Create(context.TODO(), roleBinding)
 				if err != nil {

--- a/deploy/crds/managed.openshift.io_subjectpermissions.yaml
+++ b/deploy/crds/managed.openshift.io_subjectpermissions.yaml
@@ -70,6 +70,9 @@ spec:
               subjectName:
                 description: Name of the Subject granted permissions by the operator
                 type: string
+              subjectNamespace:
+                description: Namespace of the Subject granted permissions by the operator
+                type: string
             required:
             - subjectKind
             - subjectName

--- a/pkg/const/test/test.go
+++ b/pkg/const/test/test.go
@@ -145,6 +145,24 @@ var (
 		},
 	}
 
+	TestRoleBindingSA = &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "examplePermissionClusterRoleName-exampleGroupName",
+			Namespace: "examplenamespace",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "exampleGroupName",
+				Namespace: "exampleGroupNamespace",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "ClusterRole",
+			Name: "examplePermissionClusterRoleName",
+		},
+	}
+
 	TestRoleBindingList = &rbacv1.RoleBindingList{
 		Items: []rbacv1.RoleBinding{
 			*TestRoleBinding,

--- a/pkg/controllerutils/controllerutil.go
+++ b/pkg/controllerutils/controllerutil.go
@@ -97,8 +97,8 @@ func safeListAfterDeniedRegex(namespacesDeniedRegex string, safeList []string) [
 }
 
 // NewRoleBindingForClusterRole creates and returns valid RoleBinding
-func NewRoleBindingForClusterRole(clusterRoleName, subjectName, subjectKind, namespace string) *v1.RoleBinding {
-	return &v1.RoleBinding{
+func NewRoleBindingForClusterRole(clusterRoleName, subjectName, subjectNamespace, subjectKind, namespace string) *v1.RoleBinding {
+	roleBinding := &v1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterRoleName + "-" + subjectName,
 			Namespace: namespace,
@@ -114,6 +114,12 @@ func NewRoleBindingForClusterRole(clusterRoleName, subjectName, subjectKind, nam
 			Name: clusterRoleName,
 		},
 	}
+
+	if len(subjectNamespace) > 0 {
+		roleBinding.Subjects[0].Namespace = subjectNamespace
+	}
+
+	return roleBinding
 }
 
 // UpdateCondition of SubjectPermission

--- a/pkg/controllerutils/controllerutil_test.go
+++ b/pkg/controllerutils/controllerutil_test.go
@@ -90,8 +90,13 @@ var _ = Describe("Controller Utils Tests", func() {
 	Context("Running NewRoleBindingForClusterRole", func() {
 
 		It("Should return the expected rolebinding", func() {
-			rb := NewRoleBindingForClusterRole("examplePermissionClusterRoleName", "exampleGroupName", "Group", "examplenamespace")
+			rb := NewRoleBindingForClusterRole("examplePermissionClusterRoleName", "exampleGroupName", "", "Group", "examplenamespace")
 			Expect(rb).To(Equal(testconst.TestRoleBinding))
+		})
+
+		It("Should return the expected rolebinding for SA", func() {
+			rb := NewRoleBindingForClusterRole("examplePermissionClusterRoleName", "exampleGroupName", "exampleGroupNamespace", "ServiceAccount", "examplenamespace")
+			Expect(rb).To(Equal(testconst.TestRoleBindingSA))
 		})
 	})
 


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Adds support for `subjectNamespace` so SA could be used in a SubjectPermission.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18000

### Special notes for your reviewer:
Can use kind Group with name "system:serviceaccounts:<namespace>:<serviceAccountName>" but it's not intuitive.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
