### PR TITLE
SDCICD-1178: remove fields not declared in schema

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -81,18 +81,6 @@ objects:
         namespace: openshift-rbac-permissions
       spec:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-        affinity:
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-              weight: 1
-        tolerations:
-          - effect: NoSchedule
-            key: node-role.kubernetes.io/infra
-            operator: Exists
         displayName: RBAC Permissions Operator
         icon:
           base64data: ''


### PR DESCRIPTION
### What type of PR is this?

/cleanup

### What this PR does / why we need it?

the `CatalogSource` spec does not define `affinity` and `tolerations`
fields, those are set in the `grpcPodConfig` which already exists in the
file.

```
2023-12-18T08:03:59Z	INFO	controllers.ObjectSet	API status error with empty reason string	{"ObjectSet": "/managed-openshift-release-bundle-5f548cb8bb", "err": {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"failed to create typed patch object (openshift-rbac-permissions/rbac-permissions-operator-registry; operators.coreos.com/v1alpha1, Kind=CatalogSource): .spec.tolerations: field not declared in schema","code":500}}
```

https://docs.openshift.com/container-platform/4.14/rest_api/operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.html

### Which Jira/Github issue(s) this PR fixes?

[SDCICD-1178](https://issues.redhat.com//browse/SDCICD-1178)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
