### PR TITLE
SDCICD-1183 e2e test updates

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
 
 ENV USER_UID=1001 \
     USER_NAME=rbac-permissions-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.7
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/operator-custom-metrics v0.4.3-0.20220322205053-7b528cc0d6eb
-	github.com/openshift/osde2e-common v0.0.0-20231010150014-8a4449a371e6
+	github.com/openshift/osde2e-common v0.0.0-20240111205449-2d6094e0e389
 	github.com/operator-framework/operator-lib v0.10.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.62.0
 	github.com/prometheus/client_golang v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/openshift/operator-custom-metrics v0.4.3-0.20220322205053-7b528cc0d6e
 github.com/openshift/operator-custom-metrics v0.4.3-0.20220322205053-7b528cc0d6eb/go.mod h1:ttINLaaHI1UhCW8j282QsUeDPb3qbkudMBtbHPntBM4=
 github.com/openshift/osde2e-common v0.0.0-20231010150014-8a4449a371e6 h1:MPcnO0eeWEyjLBA4mMgJ8pv8u7DjKC7yS+a39R+zhqs=
 github.com/openshift/osde2e-common v0.0.0-20231010150014-8a4449a371e6/go.mod h1:lzmkYjtdf0EgPnoujLNAzorq/7vygGCcgceo/dQI1d0=
+github.com/openshift/osde2e-common v0.0.0-20240111205449-2d6094e0e389 h1:RuqZWven2AKLwOCWGBagVEv/4adWbmYIyZNE8eUPxCs=
+github.com/openshift/osde2e-common v0.0.0-20240111205449-2d6094e0e389/go.mod h1:lzmkYjtdf0EgPnoujLNAzorq/7vygGCcgceo/dQI1d0=
 github.com/operator-framework/operator-lib v0.10.0 h1:tTjrt8Udi0msABkMpgxKHp7sXKnC73jFPO5Col0tWso=
 github.com/operator-framework/operator-lib v0.10.0/go.mod h1:sdCls/olFjSHLXU0bHlaPtmyeIdentoxz/9miyw27kw=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/osde2e/rbac_permissions_operator_tests.go
+++ b/osde2e/rbac_permissions_operator_tests.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/rbac-permissions-operator/config"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -62,19 +63,54 @@ var _ = ginkgo.Describe("rbac-permissions-operator", ginkgo.Ordered, func() {
 		var clusterRoles rbacv1.ClusterRoleList
 		err = client.List(ctx, &clusterRoles)
 		Expect(err).ShouldNot(HaveOccurred(), "failed to list clusterroles")
-		Expect(&clusterRoles).Should(ContainItemWithPrefix(clusterRolePrefix), "unable to find clusterrolebinding with prefix %s", clusterRolePrefix)
+		Expect(&clusterRoles).Should(ContainItemWithOLMOwnerWithPrefix(clusterRolePrefix), "unable to find clusterrole with olm owner with prefix %s", clusterRolePrefix)
 
 		ginkgo.By("cluster role bindings exist")
 		var clusterRoleBindings rbacv1.ClusterRoleBindingList
 		err = client.List(ctx, &clusterRoleBindings)
 		Expect(err).ShouldNot(HaveOccurred(), "unable to list clusterrolebindings")
-		Expect(&clusterRoleBindings).Should(ContainItemWithPrefix(clusterRolePrefix), "unable to find clusterrolebinding with prefix %s", clusterRolePrefix)
+		Expect(&clusterRoleBindings).Should(ContainItemWithOLMOwnerWithPrefix(clusterRolePrefix), "unable to find clusterrolebinding with olm owner with prefix %s", clusterRolePrefix)
 
 		ginkgo.By("checking the deployment is available")
 		EventuallyDeployment(ctx, client, deploymentName, namespace).Should(BeAvailable())
 	})
 
-	// TODO: ginkgo.It("reconciles subjectpermissions", func(ctx context.Context) { })
+	ginkgo.It("reconciles subjectpermissions", func(ctx context.Context) {
+		spName := "dedicated-admins"
+		testNamespaceName := "test-subjectpermissions"
+		ginkgo.By("Working in test namespace " + testNamespaceName)
+		testNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespaceName}}
+		err := client.Create(ctx, testNamespace)
+		Expect(err).ShouldNot(HaveOccurred(), "Unable to create test namespace")
+		clusterRoles, clusterRoleBindings, roleBindings := getSubjectPermissionRBACInfo(ctx, client, namespace, spName)
+
+		var allClusterRoles rbacv1.ClusterRoleList
+		err = client.WithNamespace(testNamespaceName).List(ctx, &allClusterRoles)
+		Expect(err).ShouldNot(HaveOccurred(), "failed to list clusterroles")
+		for _, clusterRoleName := range clusterRoles {
+			Expect(&allClusterRoles).Should(ContainItemWithPrefix(clusterRoleName), "subjectpermission clusterrole - "+clusterRoleName+" was not found for "+spName)
+		}
+
+		var allClusterRoleBindings rbacv1.ClusterRoleBindingList
+		err = client.WithNamespace(testNamespaceName).List(ctx, &allClusterRoleBindings)
+		Expect(err).ShouldNot(HaveOccurred(), "failed to list clusterrolebindings")
+		for _, clusterRoleBindingName := range clusterRoleBindings {
+			Expect(&allClusterRoleBindings).Should(ContainItemWithPrefix(clusterRoleBindingName), "subjectpermissions clusterrolebinding - "+clusterRoleBindingName+" was not found for "+spName)
+		}
+
+		var allRoleBindings rbacv1.RoleBindingList
+		err = client.WithNamespace(testNamespaceName).List(ctx, &allRoleBindings)
+		Expect(err).ShouldNot(HaveOccurred(), "failed to list rolebindings")
+		for _, roleBindingName := range roleBindings {
+			Expect(&allRoleBindings).Should(ContainItemWithPrefix(roleBindingName), "subjectpermissions rolebinding - "+roleBindingName+" was not found for "+spName)
+		}
+
+		ginkgo.By("Deleting test namespace " + testNamespaceName)
+		err = client.Delete(ctx, testNamespace)
+		if err != nil {
+			ginkgo.GinkgoLogr.Info("Could not delete test namespace: " + err.Error())
+		}
+	})
 
 	ginkgo.It("can be upgraded", func(ctx context.Context) {
 		ginkgo.By("forcing operator upgrade")
@@ -82,3 +118,23 @@ var _ = ginkgo.Describe("rbac-permissions-operator", ginkgo.Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")
 	})
 })
+
+func getSubjectPermissionRBACInfo(ctx context.Context, client *openshift.Client, namespace string, spName string) ([]string, []string, []string) {
+	var us managedv1alpha1.SubjectPermission
+	err := client.WithNamespace(namespace).Get(ctx, spName, namespace, &us)
+	Expect(err).ShouldNot(HaveOccurred(), "unable to get subjectpermission")
+
+	clusterRoles := us.Spec.ClusterPermissions
+
+	clusterRoleBindings := []string{}
+	for _, crName := range clusterRoles {
+		clusterRoleBindings = append(clusterRoleBindings, crName+"-"+us.Name)
+	}
+
+	roleBindings := []string{}
+	for _, perm := range us.Spec.Permissions {
+		clusterRoles = append(clusterRoles, perm.ClusterRoleName)
+		roleBindings = append(roleBindings, perm.ClusterRoleName+"-"+us.Name)
+	}
+	return clusterRoles, clusterRoleBindings, roleBindings
+}

--- a/osde2e/rbac_permissions_operator_tests.go
+++ b/osde2e/rbac_permissions_operator_tests.go
@@ -84,6 +84,11 @@ var _ = ginkgo.Describe("rbac-permissions-operator", ginkgo.Ordered, func() {
 		Expect(err).ShouldNot(HaveOccurred(), "Unable to create test namespace")
 		clusterRoles, clusterRoleBindings, roleBindings := getSubjectPermissionRBACInfo(ctx, client, namespace, spName)
 
+		ginkgo.DeferCleanup(func(ctx context.Context) {
+			ginkgo.By("Deleting test namespace " + testNamespaceName)
+			Expect(client.Delete(ctx, testNamespace)).Should(Succeed(), "Failed to test delete namespace")
+		})
+
 		var allClusterRoles rbacv1.ClusterRoleList
 		err = client.WithNamespace(testNamespaceName).List(ctx, &allClusterRoles)
 		Expect(err).ShouldNot(HaveOccurred(), "failed to list clusterroles")
@@ -105,11 +110,6 @@ var _ = ginkgo.Describe("rbac-permissions-operator", ginkgo.Ordered, func() {
 			Expect(&allRoleBindings).Should(ContainItemWithPrefix(roleBindingName), "subjectpermissions rolebinding - "+roleBindingName+" was not found for "+spName)
 		}
 
-		ginkgo.By("Deleting test namespace " + testNamespaceName)
-		err = client.Delete(ctx, testNamespace)
-		if err != nil {
-			ginkgo.GinkgoLogr.Info("Could not delete test namespace: " + err.Error())
-		}
 	})
 
 	ginkgo.It("can be upgraded", func(ctx context.Context) {


### PR DESCRIPTION
completed todo item for subjectpermissions in e2e test, Removed hardcoded crb name check

### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_
test

### What this PR does / why we need it?
1. Removed hardcoded clusterrolebinding name check. This name prefix has changes starting >4.15
2. Adds incomplete todo item for subjectpermissions check 

### Which Jira/Github issue(s) this PR fixes?
[SDCICD-1183](https://issues.redhat.com//browse/SDCICD-1183)

_Fixes #_

### Special notes for your reviewer:

 

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
