### PR TITLE
Fix lint issues

### DIFF
--- a/controllers/namespace/namespace_controller.go
+++ b/controllers/namespace/namespace_controller.go
@@ -55,7 +55,7 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 
 	// Fetch the Namespace instance
 	instance := &corev1.Namespace{}
-	err := r.Client.Get(context.TODO(), request.NamespacedName, instance)
+	err := r.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -68,14 +68,14 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 	}
 
 	namespaceList := &corev1.NamespaceList{}
-	err = r.Client.List(context.TODO(), namespaceList)
+	err = r.List(context.TODO(), namespaceList)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get namespaceList")
 		return ctrl.Result{}, err
 	}
 
 	subjectPermissionList := &managedv1alpha1.SubjectPermissionList{}
-	err = r.Client.List(context.TODO(), subjectPermissionList)
+	err = r.List(context.TODO(), subjectPermissionList)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get clusterRoleBindingList")
 		return ctrl.Result{}, err
@@ -86,7 +86,7 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 	opts := []client.ListOption{
 		client.InNamespace(request.Name),
 	}
-	err = r.Client.List(context.TODO(), roleBindingList, opts...)
+	err = r.List(context.TODO(), roleBindingList, opts...)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get rolebindingList")
 		return ctrl.Result{}, err
@@ -112,7 +112,7 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 					continue
 				}
 
-				err := r.Client.Create(context.TODO(), roleBinding)
+				err := r.Create(context.TODO(), roleBinding)
 				if err != nil {
 					if k8serr.IsAlreadyExists(err) {
 						continue

--- a/main.go
+++ b/main.go
@@ -117,15 +117,16 @@ func main() {
 
 	// Ensure lock for leader election
 	_, err = k8sutil.GetOperatorNamespace()
-	if err == nil {
+	switch err {
+	case nil:
 		err = leader.Become(context.TODO(), "rbac-permissions-operator-lock")
 		if err != nil {
 			setupLog.Error(err, "failed to create leader lock")
 			os.Exit(1)
 		}
-	} else if err == k8sutil.ErrRunLocal || err == k8sutil.ErrNoNamespace {
+	case k8sutil.ErrRunLocal, k8sutil.ErrNoNamespace:
 		setupLog.Info("Skipping leader election; not running in a cluster.")
-	} else {
+	default:
 		setupLog.Error(err, "Failed to get operator namespace")
 		os.Exit(1)
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -78,14 +78,14 @@ func deleteRBACClusterPermissionMetric(gp *managedv1alpha1.SubjectPermission) {
 	for _, clusterPermissionName := range gp.Spec.ClusterPermissions {
 		r = RBACClusterwidePermissions.DeleteLabelValues(
 			gp.Spec.SubjectName,
-			gp.ObjectMeta.GetName(),
+			gp.GetName(),
 			clusterPermissionName,
 			"1",
 		)
 		// It's possible that we weren't able to delete the metric, so let's log a message to that effect.
 		if !r {
 			log.Info(fmt.Sprintf("Failed to delete GaugeVec labels: subject_name='%s', subject_permission_name='%s', cluster_permission='%s', state='1'",
-				gp.Spec.SubjectName, gp.ObjectMeta.GetName(), clusterPermissionName))
+				gp.Spec.SubjectName, gp.GetName(), clusterPermissionName))
 		}
 	}
 }
@@ -114,7 +114,7 @@ func deleteRBACNamespacePermissionMetric(gp *managedv1alpha1.SubjectPermission) 
 	for _, permission := range gp.Spec.Permissions {
 		r = RBACNamespacePermissions.DeleteLabelValues(
 			gp.Spec.SubjectName,
-			gp.ObjectMeta.GetName(),
+			gp.GetName(),
 			permission.ClusterRoleName,
 			permission.NamespacesAllowedRegex,
 			permission.NamespacesDeniedRegex,
@@ -123,7 +123,7 @@ func deleteRBACNamespacePermissionMetric(gp *managedv1alpha1.SubjectPermission) 
 		// It's possible that we weren't able to delete the metric, so let's log a message to that effect.
 		if !r {
 			log.Info(fmt.Sprintf("Failed to delete GaugeVec labels: subject_name='%s', subject_permission_name='%s', cluster_permission='%s', state='1'",
-				gp.Spec.SubjectName, gp.ObjectMeta.GetName(), permission.ClusterRoleName))
+				gp.Spec.SubjectName, gp.GetName(), permission.ClusterRoleName))
 		}
 	}
 }


### PR DESCRIPTION
### What type of PR is this?
bug


### What this PR does / why we need it?
This PR fixes the lint issues found in https://github.com/openshift/rbac-permissions-operator/pull/200

We would like to fix the lint issue first then perform a clean boilerplate update.

```
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 GOFLAGS="-tags=fips_enabled" GOEXPERIMENT=boringcrypto GOLANGCI_LINT_CACHE=/tmp/golangci-cache golangci-lint run -c boilerplate/openshift/golang-osd-operator/golangci.yml ./...
../../../controllers/namespace/namespace_controller.go:58:11: QF1008: could remove embedded field "Client" from selector (staticcheck)
	err := r.Client.Get(context.TODO(), request.NamespacedName, instance)
	         ^
../../../controllers/namespace/namespace_controller.go:71:10: QF1008: could remove embedded field "Client" from selector (staticcheck)
	err = r.Client.List(context.TODO(), namespaceList)
	        ^
../../../controllers/namespace/namespace_controller.go:78:10: QF1008: could remove embedded field "Client" from selector (staticcheck)
	err = r.Client.List(context.TODO(), subjectPermissionList)
	        ^
../../../controllers/namespace/namespace_controller.go:89:10: QF1008: could remove embedded field "Client" from selector (staticcheck)
	err = r.Client.List(context.TODO(), roleBindingList, opts...)
	        ^
../../../controllers/namespace/namespace_controller.go:115:14: QF1008: could remove embedded field "Client" from selector (staticcheck)
				err := r.Client.Create(context.TODO(), roleBinding)
				         ^
../../../controllers/subjectpermission/subjectpermission_controller.go:62:11: QF1008: could remove embedded field "Client" from selector (staticcheck)
	err := r.Client.Get(context.TODO(), request.NamespacedName, instance)
	         ^
../../../controllers/subjectpermission/subjectpermission_controller.go:78:102: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
		reqLogger.Info(fmt.Sprintf("Removing Prometheus metrics for SubjectPermission name='%s'", instance.ObjectMeta.GetName()))
		                                                                                                   ^
../../../controllers/subjectpermission/subjectpermission_controller.go:85:10: QF1008: could remove embedded field "Client" from selector (staticcheck)
	err = r.Client.List(context.TODO(), clusterRoleList)
	        ^
../../../controllers/subjectpermission/subjectpermission_controller.go:93:10: QF1008: could remove embedded field "Client" from selector (staticcheck)
	err = r.Client.List(context.TODO(), clusterRoleBindingList)
	        ^
../../../controllers/subjectpermission/subjectpermission_controller.go:120:12: QF1008: could remove embedded field "Client" from selector (staticcheck)
		err := r.Client.Create(context.TODO(), newCRB)
		         ^
../../../controllers/subjectpermission/subjectpermission_controller.go:149:10: QF1008: could remove embedded field "Client" from selector (staticcheck)
	err = r.Client.List(context.TODO(), nsList)
	        ^
../../../controllers/subjectpermission/subjectpermission_controller.go:196:11: QF1008: could remove embedded field "Client" from selector (staticcheck)
				_ = r.Client.List(context.TODO(), rbList, opts...)
				      ^
../../../controllers/subjectpermission/subjectpermission_controller.go:201:14: QF1008: could remove embedded field "Client" from selector (staticcheck)
				err := r.Client.Create(context.TODO(), roleBinding)
				         ^
../../../main.go:120:2: QF1003: could use tagged switch on err (staticcheck)
	if err == nil {
	^
../../../pkg/metrics/metrics.go:81:7: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
			gp.ObjectMeta.GetName(),
			   ^
../../../pkg/metrics/metrics.go:88:29: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
				gp.Spec.SubjectName, gp.ObjectMeta.GetName(), clusterPermissionName))
				                        ^
../../../pkg/metrics/metrics.go:117:7: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
			gp.ObjectMeta.GetName(),
			   ^
../../../pkg/metrics/metrics.go:126:29: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
				gp.Spec.SubjectName, gp.ObjectMeta.GetName(), permission.ClusterRoleName))
				                        ^
```


### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
