### PR TITLE
SREP-4556: Add terminationMessagePolicy for OCP 4.21 conformance

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -33,6 +33,7 @@ spec:
           command:
           - rbac-permissions-operator
           imagePullPolicy: Always
+          terminationMessagePolicy: FallbackToLogsOnError
           resources:
             limits:
               cpu: 500m

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -75,6 +75,7 @@ spec:
         - name: delete-csv
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
           imagePullPolicy: Always
+          terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/deploy_pko/Deployment-rbac-permissions-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-rbac-permissions-operator.yaml.gotmpl
@@ -39,6 +39,7 @@ spec:
         command:
         - rbac-permissions-operator
         imagePullPolicy: Always
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
Adds terminationMessagePolicy: FallbackToLogsOnError to all containers in deploy/ and deploy_pko/ manifests. Required for OCP 4.21 conformance (terminationMessagePolicy monitor test).

Jira: https://redhat.atlassian.net/browse/SREP-4556
Reference: openshift/route-monitor-operator#516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container termination message policies in Kubernetes deployment and cleanup job configurations. Modified settings to ensure error messages are captured from container logs during shutdown events. These changes improve observability of container termination behavior and error reporting across deployment specifications. Applied consistently to maintain uniform error handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->