### PR TITLE
Fix PKO template: add config.image for operator deployment

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
 
 ENV USER_UID=1001 \
     USER_NAME=rbac-permissions-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -3,6 +3,8 @@ kind: Template
 parameters:
   - name: PKO_IMAGE
     required: true
+  - name: OPERATOR_IMAGE
+    required: true
   - name: IMAGE_TAG
     required: true
   - name: IMAGE_DIGEST
@@ -44,5 +46,8 @@ objects:
             annotations:
               package-operator.run/collision-protection: IfNoController
           spec:
-            # Pin image by digest for reproducibility
+            # Pin PKO package image by digest for reproducibility
             image: ${PKO_IMAGE}@${IMAGE_DIGEST}
+            config:
+              # Operator image uses same git SHA tag (built from same commit)
+              image: ${OPERATOR_IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
## Problem

The PKO deployment is failing on managed clusters with:
```
template: Deployment-rbac-permissions-operator.yaml.gotmpl:38:26: at <.config.image>: map has no entry for key "image"
```

The Deployment template expects `.config.image` but the ClusterPackage was not providing a `config` section.

## Fix

Add `config.image` to the ClusterPackage spec using `${OPERATOR_IMAGE}:${IMAGE_TAG}` to pass the operator image reference to the Deployment template.

## Testing

- Verified PKO SelectorSyncSet is applied to hive
- Found this error in PKO manager logs on managed cluster
- This fix will allow PKO to properly deploy the operator

## Related

- App-interface MR: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/185140
- JIRA: [SREP-3716](https://redhat.atlassian.net/browse/SREP-3716)

Made with [Cursor](https://cursor.com)

[SREP-3716]: https://redhat.atlassian.net/browse/SREP-3716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for pinning the operator image alongside the existing runtime image pinning in cluster package configuration.
  * Kept the existing runtime image pinning behavior and comments intact.
  * Updated base images used in build stages to newer minimal base image tags for the final build stages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->