### PR TITLE
Fix OLM cleanup job ACM conflict

### DIFF
--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -92,11 +92,12 @@ spec:
               #!/bin/sh
               set -euxo pipefail
               # Delete Subscription first to prevent OLM from recreating CSV
-              oc -n openshift-rbac-permissions delete subscription \
+              # Use full resource type to avoid conflict with ACM subscriptions.apps.open-cluster-management.io
+              oc -n openshift-rbac-permissions delete subscriptions.operators.coreos.com \
                 -l "operators.coreos.com/rbac-permissions-operator.openshift-rbac-permissions" \
                 --ignore-not-found
               # Delete ClusterServiceVersion
-              oc -n openshift-rbac-permissions delete csv \
+              oc -n openshift-rbac-permissions delete clusterserviceversions.operators.coreos.com \
                 -l "operators.coreos.com/rbac-permissions-operator.openshift-rbac-permissions" \
                 --ignore-not-found
           resources:


### PR DESCRIPTION
## Problem

OLM cleanup job fails on clusters with ACM installed:
```
subscriptions.apps.open-cluster-management.io is forbidden
```

The `oc delete subscription` command matches the wrong API group.

## Fix

Use explicit resource types with API group:
- `subscriptions.operators.coreos.com`
- `clusterserviceversions.operators.coreos.com`

## Impact

Non-blocking - RPO is running under PKO control. This just cleans up old OLM resources.

## Related

- JIRA: [SREP-3716](https://redhat.atlassian.net/browse/SREP-3716)

Made with [Cursor](https://cursor.com)

[SREP-3716]: https://redhat.atlassian.net/browse/SREP-3716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Operator Lifecycle Manager cleanup job to use full API resource type identifiers when deleting resources, preventing potential conflicts and ensuring more precise cleanup operations.
  * Enhanced cleanup reliability by properly targeting plural resource forms for deletion while maintaining existing label filtering and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->