### PR TITLE
Rename PKO SSS suffix

### DIFF
--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -24,9 +24,7 @@ objects:
         managed.openshift.io/gitHash: ${IMAGE_TAG}
         managed.openshift.io/gitRepoName: ${REPO_NAME}
         managed.openshift.io/osd: "true"
-      # NOTE: This manifest deploys to stage. For production, update the name
-      # and clusterDeploymentSelector labels accordingly.
-      name: rbac-permissions-operator-stage
+      name: rbac-permissions-operator-pko
     spec:
       clusterDeploymentSelector:
         matchLabels:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Rename the SelectorSyncSet name suffix.

The `-stage` suffix can be misleading, because we are deploying the same `/hack/pko/clusterpackage.yaml` to all INT/STG/PROD environment.

We can use the `-pko` suffix instead, so we can distinguish them from the original OLM SSS.
 
### Which Jira/Github issue(s) this PR fixes?

Relates to [SREP-4826](https://redhat.atlassian.net/browse/SREP-4826) .

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR


[SREP-4826]: https://redhat.atlassian.net/browse/SREP-4826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated RBAC Permissions Operator deployment configuration to align with the PKO environment: selector name adjusted and legacy staging comment removed to ensure manifests target the intended PKO deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->