### PR TITLE
fix: remove invalid E2E check for non-existent namespace-scoped Role

### DIFF
--- a/test/e2e/rbac_permissions_operator_tests.go
+++ b/test/e2e/rbac_permissions_operator_tests.go
@@ -29,7 +29,6 @@ var _ = ginkgo.Describe("rbac-permissions-operator", ginkgo.Ordered, func() {
 		namespace             = config.OperatorNamespace
 		deploymentName        = config.OperatorName
 		configMapLockfileName = deploymentName + "-lock"
-		rolePrefix            = deploymentName
 		clusterRolePrefix     = deploymentName
 	)
 	ginkgo.BeforeAll(func() {
@@ -49,18 +48,6 @@ var _ = ginkgo.Describe("rbac-permissions-operator", ginkgo.Ordered, func() {
 		ginkgo.By("checking the configmap lockfile exists")
 		err = client.Get(ctx, configMapLockfileName, namespace, &corev1.ConfigMap{})
 		Expect(err).ShouldNot(HaveOccurred(), "configmap lockfile %s not found", configMapLockfileName)
-
-		ginkgo.By("checking the role exists")
-		var roles rbacv1.RoleList
-		err = client.WithNamespace(namespace).List(ctx, &roles)
-		Expect(err).ShouldNot(HaveOccurred(), "failed to list roles")
-		Expect(&roles).Should(ContainItemWithPrefix(rolePrefix), "unable to find roles with prefix %s", rolePrefix)
-
-		ginkgo.By("checking the rolebinding exists")
-		var rolebindings rbacv1.RoleBindingList
-		err = client.List(ctx, &rolebindings)
-		Expect(err).ShouldNot(HaveOccurred(), "failed to list rolebindings")
-		Expect(&rolebindings).Should(ContainItemWithPrefix(rolePrefix), "unable to find rolebindings with prefix %s", rolePrefix)
 
 		ginkgo.By("checking the clusterroles exists")
 		var clusterRoles rbacv1.ClusterRoleList


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Fix invalid E2E test expectation that was checking for a namespace-scoped Role with prefix "rbac-permissions-operator" that does not exist in the PKO deployment.

The E2E test `[It] rbac-permissions-operator is installed` was failing with:
```
unable to find roles with prefix rbac-permissions-operator
```
The test assumed RPO creates a namespace-scoped Role/RoleBinding, but the actual PKO deployment only creates:
- ServiceAccount: `rbac-permissions-operator`
- ClusterRole: `rbac-permissions-operator-cluster-admin`
- ClusterRoleBinding: `rbac-permissions-operator`

The only namespace-scoped `Role/RoleBinding` in the namespace is `prometheus-k8s` (for monitoring, not operator RBAC).

### Special notes for your reviewer:
 - Other E2E test cases remain unchanged
- Assertions now match actual resources in `deploy_pko/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated RBAC operator tests to focus on cluster-scoped installation checks (ClusterRole and ClusterRoleBinding) and removed assertions for namespace-scoped Role/RoleBinding. Installation verification still checks namespace lockfile/configmap and deployment availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->