### PR TITLE
fix: update E2E test to work with PKO instead of OLM owner references

### DIFF
--- a/test/e2e/rbac_permissions_operator_tests.go
+++ b/test/e2e/rbac_permissions_operator_tests.go
@@ -29,7 +29,6 @@ var _ = ginkgo.Describe("rbac-permissions-operator", ginkgo.Ordered, func() {
 		namespace             = config.OperatorNamespace
 		deploymentName        = config.OperatorName
 		configMapLockfileName = deploymentName + "-lock"
-		clusterRolePrefix     = deploymentName
 	)
 	ginkgo.BeforeAll(func() {
 		log.SetLogger(ginkgo.GinkgoLogr)
@@ -49,17 +48,13 @@ var _ = ginkgo.Describe("rbac-permissions-operator", ginkgo.Ordered, func() {
 		err = client.Get(ctx, configMapLockfileName, namespace, &corev1.ConfigMap{})
 		Expect(err).ShouldNot(HaveOccurred(), "configmap lockfile %s not found", configMapLockfileName)
 
-		ginkgo.By("checking the clusterroles exists")
-		var clusterRoles rbacv1.ClusterRoleList
-		err = client.List(ctx, &clusterRoles)
-		Expect(err).ShouldNot(HaveOccurred(), "failed to list clusterroles")
-		Expect(&clusterRoles).Should(ContainItemWithOLMOwnerWithPrefix(clusterRolePrefix), "unable to find clusterrole with olm owner with prefix %s", clusterRolePrefix)
+		ginkgo.By("checking the clusterrole exists")
+		err = client.Get(ctx, deploymentName+"-cluster-admin", "", &rbacv1.ClusterRole{})
+		Expect(err).ShouldNot(HaveOccurred(), "clusterrole %s-cluster-admin not found", deploymentName)
 
-		ginkgo.By("cluster role bindings exist")
-		var clusterRoleBindings rbacv1.ClusterRoleBindingList
-		err = client.List(ctx, &clusterRoleBindings)
-		Expect(err).ShouldNot(HaveOccurred(), "unable to list clusterrolebindings")
-		Expect(&clusterRoleBindings).Should(ContainItemWithOLMOwnerWithPrefix(clusterRolePrefix), "unable to find clusterrolebinding with olm owner with prefix %s", clusterRolePrefix)
+		ginkgo.By("checking the clusterrolebinding exists")
+		err = client.Get(ctx, deploymentName, "", &rbacv1.ClusterRoleBinding{})
+		Expect(err).ShouldNot(HaveOccurred(), "clusterrolebinding %s not found", deploymentName)
 
 		ginkgo.By("checking the deployment is available")
 		EventuallyDeployment(ctx, client, deploymentName, namespace).Should(BeAvailable())


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Fixes E2E failure: unable to find clusterrole with olm owner with prefix rbac-permissions-operator

After migrating RPO from OLM to Package Operator (PKO), the E2E test "is installed" fails with: unable to find clusterrole with olm owner with prefix rbac-permissions-operator

The test uses `ContainItemWithOLMOwnerWithPrefix` matcher which expects:
  ```yaml
  ownerReferences:
    - kind: ClusterServiceVersion  # OLM owner
```
But PKO deployment has:
```yaml
  ownerReferences:
    - kind: ClusterObjectSet  # PKO owner
```
The ClusterRole/ClusterRoleBinding exist with correct names but are rejected by the OLM-specific matcher.

### Changes
Replace OLM owner-based matchers with direct resource name checks

### Special notes for your reviewer:
- Works with both OLM and PKO deployments
- Verified against PKO-deployed cluster where resources exist
- No changes to other test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced RBAC permissions validation in operator tests to use direct verification of specific resources instead of list-based assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->