### PR TITLE
fix: Remove the OLM upgrade test

### DIFF
--- a/test/e2e/rbac_permissions_operator_tests.go
+++ b/test/e2e/rbac_permissions_operator_tests.go
@@ -108,12 +108,6 @@ var _ = ginkgo.Describe("rbac-permissions-operator", ginkgo.Ordered, func() {
 		}
 
 	})
-
-	ginkgo.It("can be upgraded", func(ctx context.Context) {
-		ginkgo.By("forcing operator upgrade")
-		err := client.UpgradeOperator(ctx, config.OperatorName, namespace)
-		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")
-	})
 })
 
 func getSubjectPermissionRBACInfo(ctx context.Context, client *openshift.Client, namespace string, spName string) ([]string, []string, []string) {


### PR DESCRIPTION
### What type of PR is this?
Clean up / Fix

### What this PR does / why we need it?

This PR removes the OLM upgrade test in the e2e test.

Reason:
- We are hitting the below error in e2e:
```
2026/05/12 23:33:35         test case failure: "[It] rbac-permissions-operator can be upgraded" - [FAILED] operator upgrade failed
Unexpected error:
    <*fmt.wrapError | 0xc000568100>:
    unable to get subscription rbac-permissions-operator: subscriptions.operators.coreos.com "rbac-permissions-operator" not found
    {
        msg: "unable to get subscription rbac-permissions-operator: subscriptions.operators.coreos.com \"rbac-permissions-operator\" not found",
        err: <*errors.StatusError | 0xc00014a8c0>{
            ErrStatus: {
                TypeMeta: {Kind: "Status", APIVersion: "v1"},
                ListMeta: {
                    SelfLink: "",
                    ResourceVersion: "",
                    Continue: "",
                    RemainingItemCount: nil,
                },
                Status: "Failure",
                Message: "subscriptions.operators.coreos.com \"rbac-permissions-operator\" not found",
                Reason: "NotFound",
                Details: {
                    Name: "rbac-permissions-operator",
                    Group: "operators.coreos.com",
                    Kind: "subscriptions",
                    UID: "",
                    Causes: nil,
                    RetryAfterSeconds: 0,
                },
                Code: 404,
            },
        },
    }
```
- We are migrating from OLM to PKO, we won't use OLM in the future.
- Looking at how other migrated operator handle similar test cases, I can see them marked the "upgrade operator" test as `PIT`(pending), which means the test will be skipped.  [Example](https://github.com/openshift/configure-alertmanager-operator/blob/8b481ba87c1fbfc58773cc1549725b612c803bdf/test/e2e/configure_alertmanager_operator_tests.go#L1717).  I don't foresee we will need such OLM test in the future, so deleting this test case to clean it up directly.
- Besides this part, I let Claude reviewing the e2e tests, there's no anymore OLM assumptions. So removing this case should help.
- The other operators' test cases don't have PKO version for upgrade test, so I am not adding such for now.


We can add more PKO specific tests in the future, but we focus on fixing the e2e error in this PR.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an upgrade validation test from the RBAC permissions operator test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->