### PR TITLE
Refresh Dependabot auto-merge workflows (ROSA-745)

### DIFF
--- a/.github/workflows/branch-protection-check.yml
+++ b/.github/workflows/branch-protection-check.yml
@@ -2,174 +2,97 @@ name: Branch Protection Check
 
 on:
   schedule:
-    # Run weekly to verify branch protection is properly configured
     - cron: '0 9 * * 1'  # Every Monday at 9 AM UTC
-  workflow_dispatch:  # Allow manual triggering
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  verify-dependabot-config:
-    name: Verify Dependabot Configuration
+  verify-config:
+    name: Verify Dependabot and auto-merge setup
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - name: Check Dependabot Config
+      - name: Validate Dependabot and workflow configuration
         run: |
-          echo "Verifying Dependabot configuration..."
+          set -euo pipefail
+          pip install --quiet pyyaml
+          python3 <<'PY'
+          import sys
+          from pathlib import Path
 
-          if [ -f ".github/dependabot.yml" ]; then
-            echo "Dependabot configuration found"
-            echo ""
-            echo "Configuration summary:"
-            grep -A 10 "package-ecosystem:" .github/dependabot.yml || true
-          else
-            echo "Dependabot configuration missing"
-            exit 1
-          fi
+          import yaml
 
-  verify-workflows:
-    name: Verify Auto-Merge Workflows
-    runs-on: ubuntu-latest
+          def fail(msg: str) -> None:
+              print(f"❌ {msg}")
+              sys.exit(1)
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+          dependabot_path = Path(".github/dependabot.yml")
+          if not dependabot_path.is_file():
+              fail("Dependabot configuration missing (.github/dependabot.yml)")
 
-      - name: Check Required Workflows and Branch Protection
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Verifying auto-merge workflows..."
+          def load_workflow(path: Path) -> dict:
+              with path.open() as f:
+                  data = yaml.safe_load(f)
+              if not isinstance(data, dict):
+                  fail(f"{path.name} must be a YAML mapping")
+              return data
 
-          required_workflows=(
-            ".github/workflows/dependabot-auto-merge.yml"
-          )
+          with dependabot_path.open() as f:
+              cfg = yaml.safe_load(f)
+          if not isinstance(cfg, dict):
+              fail("dependabot.yml must be a YAML mapping")
+          if cfg.get("version") != 2:
+              fail("dependabot.yml: version must be 2")
+          updates = cfg.get("updates")
+          if not isinstance(updates, list) or not updates:
+              fail("dependabot.yml: updates must be a non-empty list")
+          for i, entry in enumerate(updates):
+              if not isinstance(entry, dict):
+                  fail(f"dependabot.yml: updates[{i}] must be a mapping")
+              if not entry.get("package-ecosystem"):
+                  fail(f"dependabot.yml: updates[{i}] missing package-ecosystem")
+              if "directory" not in entry:
+                  fail(f"dependabot.yml: updates[{i}] missing directory")
 
-          all_present=true
+          print("✅ dependabot.yml structure is valid")
+          for entry in updates:
+              print(f"   - {entry.get('package-ecosystem')} ({entry.get('directory')})")
 
-          for workflow in "${required_workflows[@]}"; do
-            if [ -f "$workflow" ]; then
-              echo "$workflow found"
-            else
-              echo "$workflow missing"
-              all_present=false
-            fi
-          done
+          workflow_path = Path(".github/workflows/dependabot-auto-merge.yml")
+          if not workflow_path.is_file():
+              fail("dependabot-auto-merge workflow missing")
 
-          if [ "$all_present" = false ]; then
-            echo ""
-            echo "Some required workflows are missing. Auto-merge may not work properly."
-          else
-            echo ""
-            echo "All required workflows are present"
-          fi
+          wf = load_workflow(workflow_path)
+          # PyYAML parses bare `on:` as boolean True, not the string "on"
+          on = wf.get("on") or wf.get(True)
+          if not isinstance(on, dict) or "pull_request_target" not in on:
+              fail("dependabot-auto-merge.yml must use pull_request_target trigger")
+          jobs = wf.get("jobs")
+          if not isinstance(jobs, dict) or "auto-merge" not in jobs:
+              fail("dependabot-auto-merge.yml must define jobs.auto-merge")
+          job = jobs["auto-merge"]
+          if not isinstance(job, dict):
+              fail("jobs.auto-merge must be a mapping")
+          steps = job.get("steps")
+          if not isinstance(steps, list) or not steps:
+              fail("jobs.auto-merge must define steps")
+          uses = [
+              s.get("uses", "")
+              for s in steps
+              if isinstance(s, dict)
+          ]
+          if not any("dependabot/fetch-metadata" in u for u in uses):
+              fail("jobs.auto-merge must include dependabot/fetch-metadata")
 
-          echo ""
-
-          # Verify branch protection settings
-          echo "Verifying branch protection settings for default branch..."
-
-          REPO="${{ github.repository }}"
-          BRANCH="master"
-
-          # Fetch branch protection settings
-          protection_response=$(curl -s -w "\n%{http_code}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${REPO}/branches/${BRANCH}/protection")
-
-          http_code=$(echo "$protection_response" | tail -n1)
-          protection_json=$(echo "$protection_response" | sed '$d')
-
-          if [[ "$http_code" -eq 404 ]]; then
-            echo "Branch protection is NOT enabled for ${BRANCH}"
-            echo "Missing: Branch protection rules"
-            all_present=false
-          elif [[ "$http_code" -ne 200 ]]; then
-            echo "Warning: Could not fetch branch protection settings (HTTP $http_code)"
-            echo "This may be due to insufficient permissions. Skipping branch protection validation."
-            echo "Response: $protection_json"
-          else
-            echo "Branch protection is enabled for ${BRANCH}"
-            echo ""
-
-            # Check required status checks
-            echo "Checking required status checks..."
-            status_checks=$(echo "$protection_json" | jq -r '.required_status_checks // empty')
-
-            if [[ -z "$status_checks" || "$status_checks" == "null" ]]; then
-              echo "Missing: required_status_checks is not configured"
-              all_present=false
-            else
-              strict=$(echo "$status_checks" | jq -r '.strict // false')
-              contexts=$(echo "$status_checks" | jq -r '.contexts // []')
-              checks=$(echo "$status_checks" | jq -r '.checks // []')
-
-              echo "  - Require branches to be up to date: $strict"
-
-              # Get all context names from both contexts array and checks array
-              context_count=$(echo "$contexts" | jq -r 'length')
-              checks_count=$(echo "$checks" | jq -r 'length')
-
-              if [[ "$context_count" -eq 0 && "$checks_count" -eq 0 ]]; then
-                echo "Missing: No required status checks configured"
-                all_present=false
-              else
-                echo "  - Required status checks configured: $((context_count + checks_count))"
-
-                # List the checks
-                if [[ "$context_count" -gt 0 ]]; then
-                  echo "  - Contexts:"
-                  echo "$contexts" | jq -r '.[]' | while read -r ctx; do
-                    echo "      - $ctx"
-                  done
-                fi
-
-                if [[ "$checks_count" -gt 0 ]]; then
-                  echo "  - Checks:"
-                  echo "$checks" | jq -r '.[].context' | while read -r ctx; do
-                    echo "      - $ctx"
-                  done
-                fi
-              fi
-            fi
-
-            echo ""
-
-            # Check required pull request reviews
-            echo "Checking required pull request reviews..."
-            pr_reviews=$(echo "$protection_json" | jq -r '.required_pull_request_reviews // empty')
-
-            if [[ -z "$pr_reviews" || "$pr_reviews" == "null" ]]; then
-              echo "  - Required pull request reviews: not configured (optional for auto-merge)"
-            else
-              required_approvals=$(echo "$pr_reviews" | jq -r '.required_approving_review_count // 0')
-              dismiss_stale=$(echo "$pr_reviews" | jq -r '.dismiss_stale_reviews // false')
-              echo "  - Required approving reviews: $required_approvals"
-              echo "  - Dismiss stale reviews: $dismiss_stale"
-            fi
-
-            echo ""
-
-            # Check if auto-merge is likely to work
-            echo "Checking auto-merge prerequisites..."
-            enforce_admins=$(echo "$protection_json" | jq -r '.enforce_admins.enabled // false')
-            echo "  - Enforce admins: $enforce_admins"
-          fi
-
-          echo ""
-          if [ "$all_present" = false ]; then
-            echo "Branch protection validation failed. Please configure the missing settings."
-            exit 1
-          fi
-
-          echo "Branch protection validation passed"
-          echo ""
-          echo "Note: Auto-merge relies entirely on existing repository CI checks"
-          echo "  GitHub's auto-merge waits for all required status checks"
-          echo "  to pass before merging. No separate CI workflow is needed."
+          print("✅ dependabot-auto-merge.yml structure is valid")
+          print("")
+          print("ℹ️  dependabot-auto-merge.yml enables merge via GraphQL")
+          print("   enablePullRequestAutoMerge; the PR merges only after existing")
+          print("   required status checks pass (e.g. ci/prow/*). No extra CI job.")
+          PY

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto-Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
@@ -13,115 +13,222 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    # Only run for Dependabot PRs
-    if: github.actor == 'dependabot[bot]' && github.repository == 'openshift/rbac-permissions-operator'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'openshift'
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Fetch Dependabot Metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Check PR Labels
-        id: check-labels
-        run: |
-          # Since this job only runs for Dependabot PRs (filtered at job level),
-          # we allow all Dependabot PRs regardless of labels since they are inherently dependency updates
-          echo "has-required-labels=true" >> $GITHUB_OUTPUT
-          echo "✅ Dependabot PR detected - auto-merge enabled for safe updates"
-
       - name: Enable Auto-Merge for Safe Updates
+        id: enable-auto-merge
         if: |
-          steps.check-labels.outputs.has-required-labels == 'true' && (
-            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-            steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-            steps.metadata.outputs.update-type == 'version-update:semver-digest'
-          )
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "Enabling auto-merge for ${{ steps.metadata.outputs.update-type }} update"
-          echo "Dependency: ${{ steps.metadata.outputs.dependency-names }}"
-          echo "Previous version: ${{ steps.metadata.outputs.previous-version }}"
-          echo "New version: ${{ steps.metadata.outputs.new-version }}"
-
-          # Set GH_TOKEN for curl commands (token is automatically masked in logs)
+          set -euo pipefail
           GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           export GH_TOKEN
 
-          # Get PR node ID for GraphQL mutation
-          PR_NODE_ID=$(curl -s \
+          comment_count() {
+            local marker="$1"
+            local http_code
+            http_code=$(curl -sS -w "%{http_code}" -o /tmp/comments-list.json \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments")
+            if [[ "$http_code" != "200" ]]; then
+              echo "::warning::Could not list PR comments (HTTP ${http_code})" >&2
+              echo "1"
+              return
+            fi
+            jq --arg m "$marker" '[.[] | select(.body | contains($m))] | length' /tmp/comments-list.json
+          }
+
+          post_issue_comment() {
+            local body="$1"
+            local http_code
+            http_code=$(curl -sS -w "%{http_code}" -o /tmp/comment-response.json \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -d "$(jq -n --arg body "$body" '{body: $body}')")
+            if [[ ! "$http_code" =~ ^2 ]]; then
+              echo "❌ Failed to post PR comment. HTTP status: ${http_code}"
+              cat /tmp/comment-response.json
+              echo "::warning::PR comment could not be posted"
+              return 1
+            fi
+          }
+
+          graphql_auto_merge_ok() {
+            local http_code="$1"
+            [[ "$http_code" == "200" ]] || return 1
+            jq -e '(.errors // []) | length == 0' /tmp/response.json >/dev/null 2>&1 || return 1
+            jq -e '.data.enablePullRequestAutoMerge.pullRequest != null' /tmp/response.json >/dev/null 2>&1
+          }
+
+          graphql_error_summary() {
+            jq -c '(.errors // []) | if length > 0 then . else .data end' /tmp/response.json 2>/dev/null || cat /tmp/response.json
+          }
+
+          echo "Enabling auto-merge for ${UPDATE_TYPE} update"
+          echo "Dependency: ${DEPENDENCY_NAMES}"
+
+          pr_http_code=$(curl -sS -w "%{http_code}" -o /tmp/pr-response.json \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
-            | jq -r '.node_id')
+            "https://api.github.com/repos/${REPOSITORY}/pulls/${PR_NUMBER}")
 
-          if [[ -z "$PR_NODE_ID" || "$PR_NODE_ID" == "null" ]]; then
-            echo "❌ Failed to fetch PR node ID"
+          if [[ "$pr_http_code" != "200" ]]; then
+            echo "❌ Failed to fetch PR metadata. HTTP status: ${pr_http_code}"
+            cat /tmp/pr-response.json
+            echo "auto_merge_enabled=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
-          echo "PR Node ID: $PR_NODE_ID"
+          PR_NODE_ID=$(jq -r '.node_id' /tmp/pr-response.json)
+          if [[ -z "$PR_NODE_ID" || "$PR_NODE_ID" == "null" ]]; then
+            echo "❌ Failed to parse PR node ID from response"
+            cat /tmp/pr-response.json
+            echo "auto_merge_enabled=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
 
-          # Enable auto-merge using GraphQL API (only way that works)
-          # GraphQL returns HTTP 200 even when mutations fail; errors are in the JSON body.
-          response=$(curl -s -w "%{http_code}" -o /tmp/response.json \
+          http_code=$(curl -sS -w "%{http_code}" -o /tmp/response.json \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN" \
             "https://api.github.com/graphql" \
             -d "{\"query\":\"mutation { enablePullRequestAutoMerge(input: { pullRequestId: \\\"$PR_NODE_ID\\\", mergeMethod: SQUASH }) { pullRequest { autoMergeRequest { enabledAt } } } }\"}")
 
-          if [[ "$response" -eq 200 ]] && \
-             jq -e '.errors == null and (.data.enablePullRequestAutoMerge.pullRequest.autoMergeRequest.enabledAt != null)' /tmp/response.json >/dev/null; then
+          if graphql_auto_merge_ok "$http_code"; then
             echo "✅ Auto-merge enabled successfully via GraphQL"
             cat /tmp/response.json
+            echo "auto_merge_enabled=true" >> "$GITHUB_OUTPUT"
           else
-            echo "❌ Failed to enable auto-merge. HTTP status: $response"
+            api_detail=$(graphql_error_summary)
+            echo "❌ Failed to enable auto-merge. HTTP status: ${http_code}"
             echo "Response body:"
             cat /tmp/response.json
-            echo "::warning::Could not enable auto-merge due to permissions or repository policy. Manual review is required."
+            echo "auto_merge_enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Could not enable auto-merge. PR may need manual review."
+            if [[ "$(comment_count 'Dependabot Auto-Merge Status')" -eq 0 ]]; then
+              failure_body=$(jq -rn \
+                --arg ut "$UPDATE_TYPE" \
+                --arg deps "$DEPENDENCY_NAMES" \
+                --arg prev "$PREVIOUS_VERSION" \
+                --arg new "$NEW_VERSION" \
+                --arg api "$api_detail" \
+                '@text "🤖 **Dependabot Auto-Merge Status**
 
-            # Add a comment to the PR explaining the situation (token is automatically masked)
-            curl -s -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              -d '{"body":"🤖 **Dependabot Auto-Merge Status**\n\nThis PR meets the criteria for auto-merge but could not be automatically merged due to repository permissions.\n\n**Details:**\n- Update type: ${{ steps.metadata.outputs.update-type }}\n- Dependencies: ${{ steps.metadata.outputs.dependency-names }}\n- Previous version: ${{ steps.metadata.outputs.previous-version }}\n- New version: ${{ steps.metadata.outputs.new-version }}\n\nPlease review and merge manually if appropriate."}'
+          This PR meets the criteria for auto-merge but could not be automatically merged.
+
+          **Details:**
+          - Update type: \($ut)
+          - Dependencies: \($deps)
+          - Previous version: \($prev)
+          - New version: \($new)
+          - API response: `\($api)`
+
+          Please review and merge manually if appropriate."')
+              post_issue_comment "$failure_body" || true
+            else
+              echo "Auto-merge status comment already posted; skipping duplicate"
+            fi
           fi
 
       - name: Comment on Major Version Updates
-        if: |
-          steps.check-labels.outputs.has-required-labels == 'true' &&
-          steps.metadata.outputs.update-type == 'version-update:semver-major'
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Set GH_TOKEN for curl commands (token is automatically masked in logs)
+          set -euo pipefail
           GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           export GH_TOKEN
 
-          # Add a comment to the PR explaining major version update (token is automatically masked)
-          curl -s -X POST \
+          comments_http=$(curl -sS -w "%{http_code}" -o /tmp/comments-list.json \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            -d '{"body":"🚨 **Major Version Update Detected** 🚨\n\nThis PR contains a major version update that requires manual review:\n- **Dependency:** ${{ steps.metadata.outputs.dependency-names }}\n- **Previous version:** ${{ steps.metadata.outputs.previous-version }}\n- **New version:** ${{ steps.metadata.outputs.new-version }}\n\nPlease review the changelog and breaking changes before merging.\n\nAuto-merge has been **disabled** for this PR."}'
+            "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments")
+          if [[ "$comments_http" != "200" ]]; then
+            echo "::warning::Could not list PR comments (HTTP ${comments_http})" >&2
+            exit 0
+          fi
+          existing=$(jq '[.[] | select(.body | contains("Major Version Update Detected"))] | length' /tmp/comments-list.json)
+
+          if [[ "$existing" -gt 0 ]]; then
+            echo "Major-version notice already posted; skipping duplicate comment"
+            exit 0
+          fi
+
+          major_body=$(jq -rn \
+            --arg deps "$DEPENDENCY_NAMES" \
+            --arg prev "$PREVIOUS_VERSION" \
+            --arg new "$NEW_VERSION" \
+            '@text "🚨 **Major Version Update Detected** 🚨
+
+          This PR contains a major version update that requires manual review:
+          - **Dependency:** \($deps)
+          - **Previous version:** \($prev)
+          - **New version:** \($new)
+
+          Please review the changelog and breaking changes before merging.
+
+          Auto-merge has been **disabled** for this PR."')
+
+          http_code=$(curl -sS -w "%{http_code}" -o /tmp/comment-response.json \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -d "$(jq -n --arg body "$major_body" '{body: $body}')")
+
+          if [[ ! "$http_code" =~ ^2 ]]; then
+            echo "❌ Failed to post major-version comment. HTTP status: ${http_code}"
+            cat /tmp/comment-response.json
+            echo "::warning::Major-version comment could not be posted"
+          fi
 
       - name: Log Auto-Merge Decision
+        if: always() && steps.metadata.outcome == 'success'
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AUTO_MERGE_ENABLED: ${{ steps.enable-auto-merge.outputs.auto_merge_enabled }}
         run: |
-          echo "Auto-merge decision for PR #${{ github.event.pull_request.number }}:"
-          echo "- Update type: ${{ steps.metadata.outputs.update-type }}"
-          echo "- Has required labels: ${{ steps.check-labels.outputs.has-required-labels }}"
-          echo "- Dependency: ${{ steps.metadata.outputs.dependency-names }}"
+          echo "Auto-merge decision for PR #${PR_NUMBER}:"
+          echo "- Update type: ${UPDATE_TYPE}"
+          echo "- Dependency: ${DEPENDENCY_NAMES}"
 
-          if [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-patch" ]] || \
-             [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-minor" ]] || \
-             [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-digest" ]]; then
-            if [[ "${{ steps.check-labels.outputs.has-required-labels }}" == "true" ]]; then
-              echo "✅ Auto-merge ENABLED"
-            else
-              echo "❌ Auto-merge DISABLED: Missing required labels"
-            fi
-          else
-            echo "❌ Auto-merge DISABLED: Major version update or unknown update type"
-          fi
+          case "${UPDATE_TYPE}" in
+            version-update:semver-patch|version-update:semver-minor)
+              if [[ "${AUTO_MERGE_ENABLED}" == "true" ]]; then
+                echo "✅ Auto-merge ENABLED (GraphQL mutation succeeded)"
+              elif [[ "${AUTO_MERGE_ENABLED}" == "false" ]]; then
+                echo "❌ Auto-merge NOT enabled (GraphQL mutation failed — see enable step logs)"
+              else
+                echo "⚠️ Auto-merge enable step did not complete (check workflow logs)"
+              fi
+              ;;
+            version-update:semver-major)
+              echo "❌ Auto-merge DISABLED: Major version update"
+              ;;
+            *)
+              echo "❌ Auto-merge DISABLED: Update type not eligible for auto-merge (${UPDATE_TYPE})"
+              ;;
+          esac


### PR DESCRIPTION
## Summary
Refreshes the **SREP-4015** pilot workflows to match the current **[ROSA-745](https://redhat.atlassian.net/browse/ROSA-745)** operator template (same as other Phase 1 operators).

## Why auto-merge was not working
The existing workflow used **`pull_request`** (read-only `GITHUB_TOKEN` on Dependabot PRs) and **`github.actor == dependabot[bot]`**, so it often **did not run** on reopen/sync. It also lacked the hardened GraphQL/comment handling from the fleet rollout.

## Changes
- **`dependabot-auto-merge.yml`**: `pull_request_target`, PR author guard, pinned `fetch-metadata`, validated API calls, deduped comments
- **`branch-protection-check.yml`**: structural YAML validation (dependabot + workflow)

## Note on open Dependabot PRs
Auto-merge only applies when **required checks pass**. Open PRs with failing **`ci/prow/*`** (e.g. #315) will not merge until CI is green—even after this lands.

## Test plan
- [ ] Merge after CI green
- [ ] Re-run workflow on a **new** Dependabot patch/minor PR (or `synchronize` on one with green checks) and confirm auto-merge is enabled

Made with [Cursor](https://cursor.com)

[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored branch-protection checks to a configuration-driven validator for more reliable validation of Dependabot/workflow settings.
  * Updated auto-merge behavior to enable auto-merge for patch and minor updates while skipping major updates.
  * Improved Dependabot status notifications with clearer messages and duplicate-comment prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->