### PR TITLE
cleanup: cleanup OLM catalogsource and operatorgroup

### DIFF
--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -23,6 +23,8 @@ rules:
     resources:
       - clusterserviceversions
       - subscriptions
+      - catalogsources
+      - operatorgroups
     verbs:
       - list
       - get
@@ -100,6 +102,10 @@ spec:
               oc -n openshift-rbac-permissions delete clusterserviceversions.operators.coreos.com \
                 -l "operators.coreos.com/rbac-permissions-operator.openshift-rbac-permissions" \
                 --ignore-not-found
+              # Delete operatorgroups
+              oc -n openshift-rbac-permissions delete operatorgroups.operators.coreos.com rbac-permissions-operator --ignore-not-found=true
+              # Delete catalogsources
+              oc -n openshift-rbac-permissions delete catalogsources.operators.coreos.com rbac-permissions-operator-registry --ignore-not-found=true
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_

cleanup

### What this PR does / why we need it?

This PR adds commands to the OLM cleanup job to delete catalogsource and operatorgroup.

After migrating to PKO, the OLM catalogsource and operatorgroup are no longer needed.

### Which Jira/Github issue(s) this PR fixes?

https://redhat.atlassian.net/browse/ROSAENG-1919

### Special notes for your reviewer:

Tested the command in a staging cluster.

This is similar to the MUO cleanup job:
https://github.com/openshift/managed-upgrade-operator/blob/35338f3ccd7d1212d4680bc7fd4e4728b8b34647/deploy_pko/Cleanup-OLM-Job.yaml#L97

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the cleanup process to remove additional operator lifecycle management artifacts, including catalog sources and operator groups, alongside previously supported resources for more comprehensive cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->