### PR TITLE
ROSA-745: drop Dependabot gomod (MintMaker owns go.mod)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,23 +14,3 @@ updates:
       - dependency-name: "openshift4/ose-operator-registry"
         # don't upgrade ose-operator-registry via these means
 # END boilerplate-managed
-
-  - package-ecosystem: gomod
-    directory: "/"
-    labels:
-      - "area/dependency"
-      - "ok-to-test"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      aws-sdk:
-        patterns:
-          - "github.com/aws/aws-sdk-go-v2*"
-      kubernetes:
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      openshift:
-        patterns:
-          - "github.com/openshift/*"


### PR DESCRIPTION
## Summary
- Remove **Dependabot gomod** from `.github/dependabot.yml` to avoid dual-path conflicts with MintMaker.
- **Dependabot** stays **docker-only** for `/build` image bumps.
- **Go modules** will be managed by **MintMaker** via `openshift/boilerplate#748` renovate config (`extends: openshift/boilerplate`).

## Why
This repo had a custom `package-ecosystem: gomod` block alongside MintMaker. After boilerplate #748, gomod updates should come from Renovate/MintMaker only (grouped batch + tide automerge on safe updates).

## Follow-up
- Close any open Dependabot **gomod** PRs after merge (they will not reopen).
- Run `boilerplate-update` after openshift/boilerplate#748 merges for docker `lgtm`/`approved` labels and `standard.mk` validate fix.

## Test plan
- [ ] `dependabot.yml` validates (docker only)
- [ ] No new Dependabot gomod PRs after merge
- [ ] Existing docker Dependabot PRs unaffected

## Related
- openshift/boilerplate#748
- [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) / [ROSAENG-751](https://redhat.atlassian.net/browse/ROSAENG-751)

Made with [Cursor](https://cursor.com)

[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-751]: https://redhat.atlassian.net/browse/ROSAENG-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management configuration to focus on Docker dependencies only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->