### PR TITLE
ROSA-745: sync dependabot and MintMaker gomod config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,31 +6,16 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
+      - "lgtm"
+      - "approved"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "UTC"
     ignore:
       - dependency-name: "redhat-services-prod/openshift/boilerplate"
         # don't upgrade boilerplate via these means
       - dependency-name: "openshift4/ose-operator-registry"
         # don't upgrade ose-operator-registry via these means
 # END boilerplate-managed
-
-  - package-ecosystem: gomod
-    directory: "/"
-    labels:
-      - "area/dependency"
-      - "ok-to-test"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      aws-sdk:
-        patterns:
-          - "github.com/aws/aws-sdk-go-v2*"
-      kubernetes:
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      openshift:
-        patterns:
-          - "github.com/openshift/*"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>openshift/boilerplate//.github/renovate.json"
+  ],
+  "enabledManagers": [
+    "tekton",
+    "gomod"
   ]
 }


### PR DESCRIPTION
## Summary

Config-only [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) (not `make boilerplate-update`):

- `.github/dependabot.yml` — docker-only `/build`, weekly Mon 03:00 UTC, `lgtm`/`approved`, ignores from `build/` (boilerplate #748)
- `.github/renovate.json` — `enabledManagers: [tekton, gomod]`; rules inherited via `extends` openshift/boilerplate

No `boilerplate/_data/last-boilerplate-commit` change — renovate `extends` uses live boilerplate.

## Test plan
- [ ] CI green (prow + Konflux)
- [ ] MintMaker Dependency Dashboard shows gomod after merge

Jira: [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745)
