### PR TITLE
[Project Darkstar] PSHP-577: Remediate 5 CVEs in rbac-permissions-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/rbac-permissions-operator
 
 go 1.26.0
 
+toolchain go1.26.4
+
 require (
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1


### PR DESCRIPTION
## Project Darkstar — Automated CVE Remediation

> **This PR was generated by Project Darkstar**, an automated CVE remediation tool.
> For questions or concerns, contact **Kevin Seiter** (ROSA Trust Engineering).

## Summary
- Adds `toolchain go1.26.4` directive to go.mod
- Fixes 6 Go stdlib CVEs (CVE-2026-33814, CVE-2026-42499, CVE-2026-33811, CVE-2026-39820, CVE-2026-27145, CVE-2026-42504)

## References
- Jira: [PSHP-577](https://redhat.atlassian.net/browse/PSHP-577)

[About Project Darkstar](https://source.redhat.com/departments/products_and_global_engineering/hybridplatforms/hybrid_platforms_blog/introducing_darkstar_an_experiment_in_ai_assisted_cve_remediation_for_rosa)

---
**Project Darkstar** — Automated CVE Remediation | Contact: Kevin Seiter (ROSA Trust Engineering)

[PSHP-577]: https://redhat.atlassian.net/browse/PSHP-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ