### PR TITLE
ROSAENG-60073: Increase SubjectPermission reconcile timeout to 5 minutes

### DIFF
--- a/test/e2e/rbac_permissions_operator_tests.go
+++ b/test/e2e/rbac_permissions_operator_tests.go
@@ -126,14 +126,17 @@ var _ = ginkgo.Describe("rbac-permissions-operator", ginkgo.Ordered, func() {
 			Expect(client.Delete(ctx, sp)).Should(Succeed(), "Failed to delete SubjectPermission test fixture")
 		})
 
-		// Wait for the operator to reconcile the SubjectPermission
+		// Wait for the operator to reconcile the SubjectPermission.
+		// After a delete+recreate cycle the operator's informer cache may take
+		// time to sync the new object, especially on freshly installed PKO
+		// ClusterPackage instances where the controller is still starting up.
 		ginkgo.By("Waiting for SubjectPermission to be reconciled")
 		Eventually(func(g Gomega) {
 			var reconciled managedv1alpha1.SubjectPermission
 			err := client.WithNamespace(namespace).Get(ctx, spName, namespace, &reconciled)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(reconciled.Status.Conditions).NotTo(BeEmpty(), "SubjectPermission has no status conditions yet")
-		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+		}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 
 		testNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespaceName}}
 		err := client.Create(ctx, testNamespace)


### PR DESCRIPTION
## Summary

The `reconciles subjectpermissions` test times out waiting for the operator to set status conditions on a freshly created SubjectPermission.

### Investigation

- The operator is deployed and running (deployment ready, `is installed` test passes)
- The operator has `cluster-admin` RBAC (not a permissions issue)
- The test deletes any existing `dedicated-admins` SubjectPermission, waits for deletion, then creates a fresh one
- The operator never sets status conditions on the new SP within the 2-minute timeout
- No operator logs were captured in the Prow artifacts to determine why

Possible causes:
1. Controller-runtime informer cache stale after delete+recreate of same-named object
2. Leader election delay after fresh PKO install
3. Operator error-looping on other resources and not processing the queue

### Fix

Increase the reconciliation timeout from 2 to 5 minutes with 10-second polling to accommodate slow controller startup on freshly installed PKO instances.

If this still fails, we need to add operator log collection to the test artifacts for further diagnosis.

## Evidence

Prow job [2092044648552861696](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-rbac-permissions-operator-master-rosa-sts-e2e-promotion-int/2092044648552861696):
- Install complete at `00:26:28`
- SP created at `00:28:28` (2 min after install)
- Timed out at `00:30:28` (2 min after create, 4 min after install)

Jira: https://redhat.atlassian.net/browse/ROSAENG-60073